### PR TITLE
Implement clone on the client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -34,6 +34,7 @@ static CLOUD_URL: &str = "https://cloud.axiom.co";
 ///     Ok(())
 /// }
 /// ```
+#[derive(Clone)]
 pub struct Client {
     url: String,
     pub datasets: datasets::Client,

--- a/src/datasets/client.rs
+++ b/src/datasets/client.rs
@@ -18,6 +18,7 @@ use crate::{
 
 /// Provides methods to work with Axiom datasets, including ingesting and
 /// querying.
+#[derive(Clone)]
 pub struct Client {
     http_client: http::Client,
 }

--- a/src/users/client.rs
+++ b/src/users/client.rs
@@ -1,6 +1,7 @@
 use crate::{error::Result, http, users::model::*};
 
 /// Provides methods to work with Axiom datasets.
+#[derive(Clone)]
 pub struct Client {
     http_client: http::Client,
 }


### PR DESCRIPTION
Hey ya!

I'm working on an example of using axiom with AWS lambda extensions, specifically the logs api. I'm following this example https://github.com/awslabs/aws-lambda-rust-runtime/blob/main/examples/extension-logs-custom-service/src/main.rs#L20

It requires the Service to implement the Clone trait
https://docs.rs/tower/latest/tower/make/struct.Shared.html

Would we be able to make the Axiom client implement Clone?

Thanks for publishing this library :)

