### PR TITLE
Fix blocking encoding

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,8 +51,14 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
   test:
-    name: Run tests
+    name: Run tests on ${{ matrix.runtime }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - runtime: Tokio
+          - runtime: async-std
+            flags: --no-default-features --features async-std
     steps:
       - uses: actions/checkout@v3
       - uses: axiomhq/setup-axiom@v1
@@ -74,7 +80,7 @@ jobs:
           AXIOM_DATASET_SUFFIX: ${{ github.run_id }}
         with:
           command: test
-          args: -- --test-threads 1
+          args: ${{ matrix.flags }} -- --test-threads 1
   publish_on_crates_io:
     name: Publish on crates.io
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ async-std = { version = "1", optional = true, features = ["tokio1"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
+async-std = { version = "1", features = ["attributes"] }
 serde_test = "1"
 test-context = "0.1"
 async-trait = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ flate2 = "1"
 http = "0.2"
 backoff = { version = "0.4", features = ["futures"] }
 futures = "0.3"
+tokio = { version = "1", optional = true, features = ["rt"] }
+async-std = { version = "1", optional = true, features = ["tokio1"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
@@ -37,8 +39,8 @@ futures-util = "0.3"
 
 [features]
 default = ["tokio", "default-tls"]
-tokio = ["backoff/tokio"]
-async-std = ["backoff/async-std"]
+tokio = ["backoff/tokio", "dep:tokio"]
+async-std = ["backoff/async-std", "dep:async-std"]
 default-tls = ["reqwest/default-tls"]
 native-tls = ["reqwest/native-tls"]
 rustls-tls = ["reqwest/rustls-tls"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,9 @@ pub enum Error {
     Encoding(std::io::Error),
     #[error("Duration is out of range (can't be larger than i64::MAX milliseconds)")]
     DurationOutOfRange,
+    #[cfg(feature = "tokio")]
+    #[error("Failed to join thread: {0}")]
+    JoinError(tokio::task::JoinError),
 }
 
 /// This is the manual implementation. We don't really care if the error is

--- a/tests/datasets.rs
+++ b/tests/datasets.rs
@@ -35,9 +35,21 @@ impl AsyncTestContext for Context {
     }
 }
 
+#[cfg(feature = "tokio")]
 #[test_context(Context)]
 #[tokio::test]
 async fn test_datasets(ctx: &mut Context) {
+    test_datasets_impl(ctx).await;
+}
+
+#[cfg(feature = "async-std")]
+#[test_context(Context)]
+#[async_std::test]
+async fn test_datasets(ctx: &mut Context) {
+    test_datasets_impl(ctx).await;
+}
+
+async fn test_datasets_impl(ctx: &mut Context) {
     // Let's update the dataset.
     let dataset = ctx
         .client


### PR DESCRIPTION
The Gzip-encoding is a sync operation which blocks the async executor. This PR adds `spawn_blocking` to move it to a separate thread. 
It also runs tests on the async-std runtime.