### PR TITLE
Support rate limiting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,9 @@ flate2 = "1"
 http = "0.2"
 backoff = { version = "0.4", features = ["futures"] }
 futures = "0.3"
-tokio = { version = "1", optional = true, features = ["rt"] }
+tokio = { version = "1", optional = true, features = ["rt", "sync"] }
 async-std = { version = "1", optional = true, features = ["tokio1"] }
+url = "2"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
@@ -37,6 +38,7 @@ serde_test = "1"
 test-context = "0.1"
 async-trait = "0.1"
 futures-util = "0.3"
+httpmock = "0.6"
 
 [features]
 default = ["tokio", "default-tls"]

--- a/src/datasets/client.rs
+++ b/src/datasets/client.rs
@@ -64,7 +64,7 @@ impl Client {
         };
 
         let query_params = serde_qs::to_string(&query_params)?;
-        let path = format!("/datasets/_apl?{}", query_params);
+        let path = format!("/v1/datasets/_apl?{}", query_params);
         let res = self.http_client.post(path, &req).await?;
 
         let saved_query_id = res
@@ -91,20 +91,24 @@ impl Client {
             name: dataset_name.into(),
             description: description.into(),
         };
-        self.http_client.post("/datasets", &req).await?.json().await
+        self.http_client
+            .post("/v1/datasets", &req)
+            .await?
+            .json()
+            .await
     }
 
     /// Delete the dataset with the given ID.
     pub async fn delete<N: Into<String>>(&self, dataset_name: N) -> Result<()> {
         self.http_client
-            .delete(format!("/datasets/{}", dataset_name.into()))
+            .delete(format!("/v1/datasets/{}", dataset_name.into()))
             .await
     }
 
     /// Get a dataset by its id.
     pub async fn get<N: Into<String>>(&self, dataset_name: N) -> Result<Dataset> {
         self.http_client
-            .get(format!("/datasets/{}", dataset_name.into()))
+            .get(format!("/v1/datasets/{}", dataset_name.into()))
             .await?
             .json()
             .await
@@ -113,7 +117,7 @@ impl Client {
     /// Retrieve the information of the dataset identified by its id.
     pub async fn info<N: Into<String>>(&self, dataset_name: N) -> Result<Info> {
         self.http_client
-            .get(format!("/datasets/{}/info", dataset_name.into()))
+            .get(format!("/v1/datasets/{}/info", dataset_name.into()))
             .await?
             .json()
             .await
@@ -169,7 +173,7 @@ impl Client {
 
         self.http_client
             .post_bytes(
-                format!("/datasets/{}/ingest", dataset_name.into()),
+                format!("/v1/datasets/{}/ingest", dataset_name.into()),
                 payload,
                 headers,
             )
@@ -201,7 +205,7 @@ impl Client {
 
     /// List all available datasets.
     pub async fn list(&self) -> Result<Vec<Dataset>> {
-        self.http_client.get("/datasets").await?.json().await
+        self.http_client.get("/v1/datasets").await?.json().await
     }
 
     /// Execute the given query on the dataset identified by its id.
@@ -211,7 +215,7 @@ impl Client {
         O: Into<Option<QueryOptions>>,
     {
         let path = format!(
-            "/datasets/{}/query?{}",
+            "/v1/datasets/{}/query?{}",
             dataset_name.into(),
             &opts
                 .into()
@@ -246,7 +250,7 @@ impl Client {
         let duration = duration.try_into()?;
         let req = TrimRequest::new(duration.into());
         self.http_client
-            .post(format!("/datasets/{}/trim", dataset_name.into()), &req)
+            .post(format!("/v1/datasets/{}/trim", dataset_name.into()), &req)
             .await?
             .json()
             .await
@@ -259,7 +263,7 @@ impl Client {
         req: DatasetUpdateRequest,
     ) -> Result<Dataset> {
         self.http_client
-            .put(format!("/datasets/{}", dataset_name.into()), &req)
+            .put(format!("/v1/datasets/{}", dataset_name.into()), &req)
             .await?
             .json()
             .await

--- a/src/datasets/model.rs
+++ b/src/datasets/model.rs
@@ -190,7 +190,7 @@ pub struct TrimResult {
 }
 
 /// Returned on event ingestion operation.
-#[derive(Deserialize, Debug, Default)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct IngestStatus {
     /// Amount of events that have been ingested.

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,8 @@ use serde::Deserialize;
 use std::fmt;
 use thiserror::Error;
 
+use crate::limits::Limits;
+
 /// A `Result` alias where the `Err` case is `axiom::Error`.
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -40,6 +42,10 @@ pub enum Error {
     #[cfg(feature = "tokio")]
     #[error("Failed to join thread: {0}")]
     JoinError(tokio::task::JoinError),
+    #[error("Rate limit exceeded: {0}")]
+    RateLimitExceeded(Limits),
+    #[error("Invalid URL: {0}")]
+    InvalidUrl(url::ParseError),
 }
 
 /// This is the manual implementation. We don't really care if the error is

--- a/src/http.rs
+++ b/src/http.rs
@@ -44,7 +44,7 @@ impl Client {
     {
         let base_url = Url::parse(base_url.as_ref())
             .map_err(Error::InvalidUrl)?
-            .join("api/v1/")
+            .join("api/")
             .map_err(Error::InvalidUrl)?;
         let token = token.into();
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,11 +1,19 @@
+#[cfg(feature = "async-std")]
+use async_std::sync::Mutex;
 use backoff::{future::retry, ExponentialBackoffBuilder};
 use bytes::Bytes;
-pub use http::HeaderMap;
-use reqwest::header;
+use http::header;
+pub(crate) use http::HeaderMap;
 use serde::{de::DeserializeOwned, Serialize};
-use std::{env, future::Future, result::Result as StdResult, time::Duration};
+use std::{env, sync::Arc, time::Duration};
+#[cfg(feature = "tokio")]
+use tokio::sync::Mutex;
+use url::Url;
 
-use crate::error::{AxiomError, Error, Result};
+use crate::{
+    error::{AxiomError, Error, Result},
+    limits::{Limit, Limits},
+};
 
 static USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
@@ -13,23 +21,40 @@ static USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_V
 /// prepending the base url.
 #[derive(Clone)]
 pub(crate) struct Client {
-    base_url: String,
+    base_url: Url,
     inner: reqwest::Client,
+    ingest_limit: Arc<Mutex<Option<Limits>>>,
+    query_limit: Arc<Mutex<Option<Limits>>>,
+}
+
+#[derive(Clone)]
+pub(crate) enum Body {
+    Empty,
+    Json(serde_json::Value),
+    Bytes(Bytes),
 }
 
 impl Client {
     /// Creates a new client.
-    pub(crate) fn new<S: Into<String>>(base_url: S, token: S, org_id: Option<S>) -> Result<Self> {
-        let base_url = format!("{}/api/v1", base_url.into());
+    pub(crate) fn new<U, T, O>(base_url: U, token: T, org_id: O) -> Result<Self>
+    where
+        U: AsRef<str>,
+        T: Into<String>,
+        O: Into<Option<String>>,
+    {
+        let base_url = Url::parse(base_url.as_ref())
+            .map_err(Error::InvalidUrl)?
+            .join("api/v1/")
+            .map_err(Error::InvalidUrl)?;
         let token = token.into();
 
         let mut default_headers = header::HeaderMap::new();
         let token_header_value = header::HeaderValue::from_str(&format!("Bearer {}", token))
             .map_err(|_e| Error::InvalidToken)?;
         default_headers.insert(header::AUTHORIZATION, token_header_value);
-        if let Some(org_id) = org_id {
+        if let Some(org_id) = org_id.into() {
             let org_id_header_value =
-                header::HeaderValue::from_str(&org_id.into()).map_err(|_e| Error::InvalidOrgId)?;
+                header::HeaderValue::from_str(&org_id).map_err(|_e| Error::InvalidOrgId)?;
             default_headers.insert("X-Axiom-Org-Id", org_id_header_value);
         }
 
@@ -42,21 +67,47 @@ impl Client {
         Ok(Self {
             base_url,
             inner: http_client,
+            ingest_limit: Arc::new(Mutex::new(None)),
+            query_limit: Arc::new(Mutex::new(None)),
         })
     }
 
-    async fn retry<F, Fut>(f: F) -> Result<Response>
+    async fn execute<P, H>(
+        &self,
+        method: http::Method,
+        path: P,
+        body: Body,
+        headers: H,
+    ) -> Result<Response>
     where
-        F: Fn() -> Fut,
-        Fut: Future<Output = StdResult<reqwest::Response, reqwest::Error>>,
+        P: AsRef<str>,
+        H: Into<Option<HeaderMap>>,
     {
+        let url = self
+            .base_url
+            .join(path.as_ref().trim_start_matches('/'))
+            .map_err(Error::InvalidUrl)?;
+
+        self.check_limits(url.path()).await?;
+
+        let headers = headers.into();
         let backoff = ExponentialBackoffBuilder::new()
             .with_initial_interval(Duration::from_millis(500)) // first retry after 500ms
             .with_multiplier(2.0) // all following retries are twice as long as the previous one
             .with_max_elapsed_time(Some(Duration::from_secs(30))) // try up to 30s
             .build();
-        retry(backoff, || async {
-            f().await.map_err(|e| {
+
+        let res = retry(backoff, || async {
+            let mut req = self.inner.request(method.clone(), url.clone());
+            if let Some(headers) = headers.clone() {
+                req = req.headers(headers);
+            }
+            match body.clone() {
+                Body::Empty => {}
+                Body::Json(value) => req = req.json(&value),
+                Body::Bytes(bytes) => req = req.body(bytes),
+            }
+            self.inner.execute(req.build()?).await.map_err(|e| {
                 if let Some(status) = e.status() {
                     if status.is_client_error() {
                         // Don't retry 4XX
@@ -69,24 +120,66 @@ impl Client {
         })
         .await
         .map(Response::new)
-        .map_err(Error::Http)
+        .map_err(Error::Http)?;
+
+        self.update_limits(&res.limits).await;
+
+        Ok(res)
+    }
+
+    async fn check_limits(&self, path: &str) -> Result<()> {
+        if path.ends_with("/ingest") {
+            let limits = self.ingest_limit.lock().await;
+            if let Some(limits) = limits.as_ref() {
+                if limits.is_exceeded() {
+                    return Err(Error::RateLimitExceeded(limits.clone()));
+                }
+            }
+        } else if path.ends_with("/query") || path.ends_with("/_apl") {
+            let limits = self.query_limit.lock().await;
+            if let Some(limits) = limits.as_ref() {
+                if limits.is_exceeded() {
+                    return Err(Error::RateLimitExceeded(limits.clone()));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn update_limits(&self, limit: &Option<Limit>) {
+        match limit {
+            Some(Limit::Ingest(limit)) => {
+                let mut ingest_limit = self.ingest_limit.lock().await;
+                ingest_limit.replace(limit.clone());
+            }
+            Some(Limit::Query(limit)) => {
+                let mut query_limit = self.query_limit.lock().await;
+                query_limit.replace(limit.clone());
+            }
+            _ => {}
+        };
     }
 
     pub(crate) async fn get<S>(&self, path: S) -> Result<Response>
     where
-        S: Into<String>,
+        S: AsRef<str>,
     {
-        let url = format!("{}{}", self.base_url, path.into());
-        Self::retry(|| async { self.inner.get(&url).send().await }).await
+        self.execute(http::Method::GET, path.as_ref(), Body::Empty, None)
+            .await
     }
 
     pub(crate) async fn post<S, P>(&self, path: S, payload: P) -> Result<Response>
     where
-        S: Into<String>,
+        S: AsRef<str>,
         P: Serialize,
     {
-        let url = format!("{}{}", self.base_url, path.into());
-        Self::retry(|| async { self.inner.post(&url).json(&payload).send().await }).await
+        self.execute(
+            http::Method::POST,
+            path,
+            Body::Json(serde_json::to_value(payload).map_err(Error::Serialize)?),
+            None,
+        )
+        .await
     }
 
     pub(crate) async fn post_bytes<S, P, H>(
@@ -96,41 +189,38 @@ impl Client {
         headers: H,
     ) -> Result<Response>
     where
-        S: Into<String>,
+        S: AsRef<str>,
         P: Into<Bytes>,
         H: Into<Option<HeaderMap>>,
     {
-        let url = format!("{}{}", self.base_url, path.into());
-        let payload = payload.into();
-        let headers = headers.into().unwrap_or(HeaderMap::new());
-        Self::retry(|| async {
-            self.inner
-                .post(&url)
-                .body(payload.clone())
-                .headers(headers.clone())
-                .send()
-                .await
-        })
+        self.execute(
+            http::Method::POST,
+            path,
+            Body::Bytes(payload.into()),
+            headers,
+        )
         .await
     }
 
     pub(crate) async fn put<S, P>(&self, path: S, payload: P) -> Result<Response>
     where
-        S: Into<String>,
+        S: AsRef<str>,
         P: Serialize,
     {
-        let url = format!("{}{}", self.base_url, path.into());
-        Self::retry(|| async { self.inner.put(&url).json(&payload).send().await }).await
+        self.execute(
+            http::Method::PUT,
+            path,
+            Body::Json(serde_json::to_value(payload).map_err(Error::Serialize)?),
+            None,
+        )
+        .await
     }
 
     pub(crate) async fn delete<S>(&self, path: S) -> Result<()>
     where
-        S: Into<String>,
+        S: AsRef<str>,
     {
-        let url = format!("{}{}", self.base_url, path.into());
-        Self::retry(|| async { self.inner.delete(&url).send().await })
-            .await?
-            .check_error()
+        self.execute(http::Method::DELETE, path, Body::Empty, None)
             .await?;
         Ok(())
     }
@@ -138,11 +228,13 @@ impl Client {
 
 pub(crate) struct Response {
     inner: reqwest::Response,
+    limits: Option<Limit>,
 }
 
 impl Response {
     pub(crate) fn new(inner: reqwest::Response) -> Self {
-        Self { inner }
+        let limits = Limit::try_from(&inner);
+        Self { inner, limits }
     }
 
     pub(crate) async fn json<T: DeserializeOwned>(self) -> Result<T> {
@@ -157,6 +249,12 @@ impl Response {
     pub(crate) async fn check_error(self) -> Result<Response> {
         let status = self.inner.status();
         if !status.is_success() {
+            if status == http::StatusCode::TOO_MANY_REQUESTS {
+                if let Some(limits) = self.limits {
+                    return Err(Error::RateLimitExceeded(limits.into_inner()));
+                }
+            }
+
             let e = match self.inner.json::<AxiomError>().await {
                 Ok(mut e) => {
                     e.status = status.as_u16();
@@ -187,5 +285,268 @@ impl From<reqwest::Response> for Response {
 impl From<Response> for reqwest::Response {
     fn from(res: Response) -> Self {
         res.inner
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use chrono::{Duration, Utc};
+    use httpmock::prelude::*;
+    use serde_json::json;
+
+    use crate::{
+        datasets::{AplQueryResult, CacheStatus, IngestStatus, Query, QueryStatus, Timeseries},
+        limits, Client, Error,
+    };
+
+    #[tokio::test]
+    async fn test_ingest_limit_exceeded() -> Result<(), Box<dyn std::error::Error>> {
+        let expires_after = Duration::seconds(1);
+        let tomorrow = Utc::now() + expires_after;
+
+        let server = MockServer::start();
+        let rate_mock = server.mock(|when, then| {
+            when.method(POST).path("/api/v1/datasets/test/ingest");
+            then.status(429)
+                .json_body(json!({ "message": "rate limit exceeded" }))
+                .header(limits::HEADER_INGEST_LIMIT, "42")
+                .header(limits::HEADER_INGEST_REMAINING, "0")
+                .header(
+                    limits::HEADER_INGEST_RESET,
+                    format!("{}", tomorrow.timestamp()),
+                );
+        });
+
+        let client = Client::builder()
+            .no_env()
+            .with_url(server.base_url())
+            .with_token("xapt-nope")
+            .build()?;
+
+        match client
+            .datasets
+            .ingest("test", vec![json!({"foo": "bar"})])
+            .await
+        {
+            Err(Error::RateLimitExceeded(limits)) => {
+                assert_eq!(limits.limit, 42);
+                assert_eq!(limits.remaining, 0);
+                assert_eq!(limits.reset.timestamp(), tomorrow.timestamp());
+            }
+            res => panic!("Expected ingest limit error, got {:?}", res),
+        };
+
+        rate_mock.assert_hits_async(1).await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_ingest_limit_exceeded_shortcircuit() -> Result<(), Box<dyn std::error::Error>> {
+        let expires_after = Duration::seconds(1);
+        let tomorrow = Utc::now() + expires_after;
+
+        let server = MockServer::start();
+        let rate_mock = server.mock(|when, then| {
+            let ingest_status = IngestStatus {
+                ingested: 1,
+                failed: 0,
+                failures: vec![],
+                processed_bytes: 32,
+                blocks_created: 1,
+                wal_length: 42,
+            };
+            when.method(POST).path("/api/v1/datasets/test/ingest");
+            then.status(200)
+                .json_body(serde_json::to_value(ingest_status).unwrap())
+                .header(limits::HEADER_INGEST_LIMIT, "42")
+                .header(limits::HEADER_INGEST_REMAINING, "0")
+                .header(
+                    limits::HEADER_INGEST_RESET,
+                    format!("{}", tomorrow.timestamp()),
+                );
+        });
+
+        let client = Client::builder()
+            .no_env()
+            .with_url(server.base_url())
+            .with_token("xapt-nope")
+            .build()?;
+
+        // First request should be ok, but the rate limit should be saved on the
+        // client.
+        client
+            .datasets
+            .ingest("test", vec![json!({"foo": "bar"})])
+            .await?;
+
+        // Second request should abort early due to saved rate limit.
+        match client
+            .datasets
+            .ingest("test", vec![json!({"foo": "bar"})])
+            .await
+        {
+            Err(Error::RateLimitExceeded(limits)) => {
+                assert_eq!(limits.limit, 42);
+                assert_eq!(limits.remaining, 0);
+                assert_eq!(limits.reset.timestamp(), tomorrow.timestamp());
+            }
+            res => panic!("Expected ingest limit error, got {:?}", res),
+        };
+
+        // After a second, the rate limit should be reset and we should be able
+        // to do another request.
+        tokio::time::sleep(expires_after.to_std()?).await;
+        client
+            .datasets
+            .ingest("test", vec![json!({"foo": "bar"})])
+            .await?;
+
+        rate_mock.assert_hits_async(2).await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_query_limit_exceeded() -> Result<(), Box<dyn std::error::Error>> {
+        let expires_after = Duration::seconds(1);
+        let tomorrow = Utc::now() + expires_after;
+
+        let server = MockServer::start();
+        let rate_mock = server.mock(|when, then| {
+            when.method(POST).path("/api/v1/datasets/_apl");
+            then.status(429)
+                .json_body(json!({ "message": "rate limit exceeded" }))
+                .header(limits::HEADER_QUERY_LIMIT, "42")
+                .header(limits::HEADER_QUERY_REMAINING, "0")
+                .header(
+                    limits::HEADER_QUERY_RESET,
+                    format!("{}", tomorrow.timestamp()),
+                );
+        });
+
+        let client = Client::builder()
+            .no_env()
+            .with_url(server.base_url())
+            .with_token("xapt-nope")
+            .build()?;
+
+        match client.datasets.apl_query("test | count", None).await {
+            Err(Error::RateLimitExceeded(limits)) => {
+                assert_eq!(limits.limit, 42);
+                assert_eq!(limits.remaining, 0);
+                assert_eq!(limits.reset.timestamp(), tomorrow.timestamp());
+            }
+            res => panic!("Expected ingest limit error, got {:?}", res),
+        };
+
+        rate_mock.assert_hits_async(1).await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_query_limit_exceeded_shortcircuit() -> Result<(), Box<dyn std::error::Error>> {
+        let expires_after = Duration::seconds(1);
+        let tomorrow = Utc::now() + expires_after;
+
+        let server = MockServer::start();
+        let rate_mock = server.mock(|when, then| {
+            let query_result = AplQueryResult {
+                request: Query::default(),
+                status: QueryStatus {
+                    elapsed_time: 0,
+                    blocks_examined: 0,
+                    rows_examined: 0,
+                    rows_matched: 0,
+                    num_groups: 0,
+                    is_partial: false,
+                    continuation_token: None,
+                    is_estimate: false,
+                    cache_status: CacheStatus::Miss,
+                    min_block_time: Utc::now() - Duration::seconds(1),
+                    max_block_time: Utc::now(),
+                    messages: vec![],
+                },
+                matches: vec![],
+                buckets: Timeseries {
+                    series: vec![],
+                    totals: vec![],
+                },
+                saved_query_id: None,
+            };
+            when.method(POST).path("/api/v1/datasets/_apl");
+            then.status(200)
+                .json_body(serde_json::to_value(query_result).unwrap())
+                .header(limits::HEADER_QUERY_LIMIT, "42")
+                .header(limits::HEADER_QUERY_REMAINING, "0")
+                .header(
+                    limits::HEADER_QUERY_RESET,
+                    format!("{}", tomorrow.timestamp()),
+                );
+        });
+
+        let client = Client::builder()
+            .no_env()
+            .with_url(server.base_url())
+            .with_token("xapt-nope")
+            .build()?;
+
+        // First request should be ok, but the rate limit should be saved on the
+        // client.
+        client.datasets.apl_query("test | count", None).await?;
+
+        // Second request should abort early due to saved rate limit.
+        match client.datasets.apl_query("test | count", None).await {
+            Err(Error::RateLimitExceeded(limits)) => {
+                assert_eq!(limits.limit, 42);
+                assert_eq!(limits.remaining, 0);
+                assert_eq!(limits.reset.timestamp(), tomorrow.timestamp());
+            }
+            res => panic!("Expected ingest limit error, got {:?}", res),
+        };
+
+        // After a second, the rate limit should be reset and we should be able
+        // to do another request.
+        tokio::time::sleep(expires_after.to_std()?).await;
+        client.datasets.apl_query("test | count", None).await?;
+
+        rate_mock.assert_hits_async(2).await;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_rate_limit_exceeded() -> Result<(), Box<dyn std::error::Error>> {
+        let expires_after = Duration::seconds(1);
+        let tomorrow = Utc::now() + expires_after;
+
+        let server = MockServer::start();
+        let rate_mock = server.mock(|when, then| {
+            when.method(GET).path("/api/v1/datasets");
+            then.status(429)
+                .json_body(json!({ "message": "rate limit exceeded" }))
+                .header(limits::HEADER_RATE_SCOPE, "user")
+                .header(limits::HEADER_RATE_LIMIT, "42")
+                .header(limits::HEADER_RATE_REMAINING, "0")
+                .header(
+                    limits::HEADER_RATE_RESET,
+                    format!("{}", tomorrow.timestamp()),
+                );
+        });
+
+        let client = Client::builder()
+            .no_env()
+            .with_url(server.base_url())
+            .with_token("xapt-nope")
+            .build()?;
+
+        match client.datasets.list().await {
+            Err(Error::RateLimitExceeded(limits)) => {
+                assert_eq!(limits.limit, 42);
+                assert_eq!(limits.remaining, 0);
+                assert_eq!(limits.reset.timestamp(), tomorrow.timestamp());
+            }
+            res => panic!("Expected ingest limit error, got {:?}", res),
+        };
+
+        rate_mock.assert_hits_async(1).await;
+        Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 pub mod client;
 pub mod error;
 mod http;
+pub mod limits;
 mod serde;
 
 pub mod datasets;

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -1,0 +1,139 @@
+//! Rate-limit type definitions.
+
+use chrono::{DateTime, TimeZone, Utc};
+use http::header;
+use std::fmt::Display;
+use thiserror::Error;
+
+pub(crate) const HEADER_QUERY_LIMIT: &str = "X-QueryLimit-Limit";
+pub(crate) const HEADER_QUERY_REMAINING: &str = "X-QueryLimit-Remaining";
+pub(crate) const HEADER_QUERY_RESET: &str = "X-QueryLimit-Reset";
+
+pub(crate) const HEADER_INGEST_LIMIT: &str = "X-IngestLimit-Limit";
+pub(crate) const HEADER_INGEST_REMAINING: &str = "X-IngestLimit-Remaining";
+pub(crate) const HEADER_INGEST_RESET: &str = "X-IngestLimit-Reset";
+
+pub(crate) const HEADER_RATE_SCOPE: &str = "X-RateLimit-Scope";
+pub(crate) const HEADER_RATE_LIMIT: &str = "X-RateLimit-Limit";
+pub(crate) const HEADER_RATE_REMAINING: &str = "X-RateLimit-Remaining";
+pub(crate) const HEADER_RATE_RESET: &str = "X-RateLimit-Reset";
+
+#[derive(Error, Debug)]
+pub(crate) enum Error {
+    #[error("Invalid limit header")]
+    InvalidLimitHeader,
+    #[error("Invalid remaining header")]
+    InvalidRemainingHeader,
+    #[error("Invalid reset header")]
+    InvalidResetHeader,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum Limit {
+    Query(Limits),
+    Ingest(Limits),
+    Rate(String, Limits),
+}
+
+impl Limit {
+    pub(crate) fn into_inner(self) -> Limits {
+        match self {
+            Limit::Query(l) => l,
+            Limit::Ingest(l) => l,
+            Limit::Rate(_, l) => l,
+        }
+    }
+
+    pub(crate) fn try_from(response: &reqwest::Response) -> Option<Self> {
+        let path = response.url().path();
+        if path.ends_with("/ingest") {
+            Limits::from_headers(
+                response.headers(),
+                HEADER_INGEST_LIMIT,
+                HEADER_INGEST_REMAINING,
+                HEADER_INGEST_RESET,
+            )
+            .map(|limits| Limit::Ingest(limits))
+            .ok()
+        } else if path.ends_with("/query") || path.ends_with("/_apl") {
+            Limits::from_headers(
+                response.headers(),
+                HEADER_QUERY_LIMIT,
+                HEADER_QUERY_REMAINING,
+                HEADER_QUERY_RESET,
+            )
+            .map(|limits| Limit::Query(limits))
+            .ok()
+        } else {
+            let scope = response
+                .headers()
+                .get(HEADER_RATE_SCOPE)
+                .and_then(|limit| limit.to_str().ok());
+            let limits = Limits::from_headers(
+                response.headers(),
+                HEADER_RATE_LIMIT,
+                HEADER_RATE_REMAINING,
+                HEADER_RATE_RESET,
+            )
+            .ok();
+
+            scope
+                .zip(limits)
+                .map(|(scope, limits)| Limit::Rate(scope.to_string(), limits))
+        }
+    }
+}
+
+/// Rate-limit information.
+#[derive(Debug, Clone)]
+pub struct Limits {
+    /// The maximum limit a client is limited to for a specified time window
+    /// which resets at the time indicated by `reset`.
+    pub limit: u64,
+    /// The remaining count towards the maximum limit.
+    pub remaining: u64,
+    /// The time at which the current limit time window will reset.
+    pub reset: DateTime<Utc>,
+}
+
+impl Display for Limits {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}/{} remaining until {}",
+            self.remaining, self.limit, self.reset
+        )
+    }
+}
+
+impl Limits {
+    pub fn is_exceeded(&self) -> bool {
+        return self.remaining == 0 && self.reset > Utc::now();
+    }
+
+    fn from_headers(
+        headers: &header::HeaderMap,
+        header_limit: &str,
+        header_remaining: &str,
+        header_reset: &str,
+    ) -> Result<Self, Error> {
+        Ok(Limits {
+            limit: headers
+                .get(header_limit)
+                .and_then(|limit| Some(limit.to_str().unwrap()))
+                .and_then(|limit| Some(limit.parse::<u64>().unwrap()))
+                .ok_or_else(|| Error::InvalidLimitHeader)?,
+            remaining: headers
+                .get(header_remaining)
+                .and_then(|limit| limit.to_str().ok())
+                .and_then(|limit| limit.parse::<u64>().ok())
+                .ok_or_else(|| Error::InvalidRemainingHeader)?,
+            reset: headers
+                .get(header_reset)
+                .and_then(|limit| limit.to_str().ok())
+                .and_then(|limit| limit.parse::<i64>().ok())
+                .map(|limit| Utc.timestamp(limit, 0))
+                .ok_or_else(|| Error::InvalidResetHeader)?,
+        })
+    }
+}

--- a/src/users/client.rs
+++ b/src/users/client.rs
@@ -13,6 +13,6 @@ impl Client {
 
     /// Retrieve the authenticated user.
     pub async fn current(&self) -> Result<AuthenticatedUser> {
-        self.http_client.get("/user").await?.json().await
+        self.http_client.get("/v1/user").await?.json().await
     }
 }


### PR DESCRIPTION
This adds support for rate limiting. It also moves the `/v1` prefix to the route level so we can upgrade individual routes.