### PR TITLE
Make `users::User` public

### DIFF
--- a/src/users/client.rs
+++ b/src/users/client.rs
@@ -12,7 +12,7 @@ impl Client {
     }
 
     /// Retrieve the authenticated user.
-    pub async fn current(&self) -> Result<AuthenticatedUser> {
+    pub async fn current(&self) -> Result<User> {
         self.http_client.get("/v1/user").await?.json().await
     }
 }

--- a/src/users/mod.rs
+++ b/src/users/mod.rs
@@ -3,3 +3,4 @@ mod client;
 mod model;
 
 pub use client::Client;
+pub use model::*;

--- a/src/users/model.rs
+++ b/src/users/model.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 /// An authenticated Axiom user.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
-pub struct AuthenticatedUser {
+pub struct User {
     pub id: String,
     pub name: String,
     pub emails: Vec<String>,


### PR DESCRIPTION
The `User` struct (previously called `AuthenticatedUser`) was not
exposed, rendering the `Client.users.current()` method almost useless.