### PR TITLE
Update rate limit logic

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,8 @@ pub enum Error {
     RateLimitExceeded { scope: String, limits: Limits },
     #[error("Query limit exceeded: {0}")]
     QueryLimitExceeded(Limits),
+    #[error("Ingest limit exceeded: {0}")]
+    IngestLimitExceeded(Limits),
     #[error("Invalid URL: {0}")]
     InvalidUrl(url::ParseError),
     #[error("Error in ingest stream: {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,8 +42,10 @@ pub enum Error {
     #[cfg(feature = "tokio")]
     #[error("Failed to join thread: {0}")]
     JoinError(tokio::task::JoinError),
-    #[error("Rate limit exceeded: {0}")]
-    RateLimitExceeded(Limits),
+    #[error("Rate limit exceeded for the {scope} scope: {limits}")]
+    RateLimitExceeded { scope: String, limits: Limits },
+    #[error("Query limit exceeded: {0}")]
+    QueryLimitExceeded(Limits),
     #[error("Invalid URL: {0}")]
     InvalidUrl(url::ParseError),
     #[error("Error in ingest stream: {0}")]

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -5,12 +5,14 @@ use http::header;
 use std::fmt::Display;
 use thiserror::Error;
 
-pub(crate) const STATUS_QUERY_LIMIT_EXCEEDED: u16 = 430;
 pub(crate) const HEADER_QUERY_LIMIT: &str = "X-QueryLimit-Limit";
 pub(crate) const HEADER_QUERY_REMAINING: &str = "X-QueryLimit-Remaining";
 pub(crate) const HEADER_QUERY_RESET: &str = "X-QueryLimit-Reset";
 
-pub(crate) const STATUS_RATE_LIMIT_EXCEEDED: u16 = 429;
+pub(crate) const HEADER_INGEST_LIMIT: &str = "X-IngestLimit-Limit";
+pub(crate) const HEADER_INGEST_REMAINING: &str = "X-IngestLimit-Remaining";
+pub(crate) const HEADER_INGEST_RESET: &str = "X-IngestLimit-Reset";
+
 pub(crate) const HEADER_RATE_SCOPE: &str = "X-RateLimit-Scope";
 pub(crate) const HEADER_RATE_LIMIT: &str = "X-RateLimit-Limit";
 pub(crate) const HEADER_RATE_REMAINING: &str = "X-RateLimit-Remaining";
@@ -28,6 +30,7 @@ pub(crate) enum InvalidHeaderError {
 
 #[derive(Debug, Clone)]
 pub(crate) enum Limit {
+    Ingest(Limits),
     Query(Limits),
     Rate(String, Limits),
 }
@@ -35,7 +38,7 @@ pub(crate) enum Limit {
 impl Limit {
     pub(crate) fn try_from(response: &reqwest::Response) -> Option<Self> {
         match response.status().as_u16() {
-            STATUS_RATE_LIMIT_EXCEEDED => {
+            429 => {
                 // Rate limit
                 let scope = response
                     .headers()
@@ -53,16 +56,27 @@ impl Limit {
                     .zip(limits)
                     .map(|(scope, limits)| Limit::Rate(scope.to_string(), limits))
             }
-            STATUS_QUERY_LIMIT_EXCEEDED => {
-                // Query limit
-                Limits::from_headers(
+            430 => {
+                // Query or ingest limit
+                let query_limit = Limits::from_headers(
                     response.headers(),
                     HEADER_QUERY_LIMIT,
                     HEADER_QUERY_REMAINING,
                     HEADER_QUERY_RESET,
                 )
                 .map(Limit::Query)
-                .ok()
+                .ok();
+                let ingest_limit = Limits::from_headers(
+                    response.headers(),
+                    HEADER_INGEST_LIMIT,
+                    HEADER_INGEST_REMAINING,
+                    HEADER_INGEST_RESET,
+                )
+                .map(Limit::Ingest)
+                .ok();
+
+                // Can't have both
+                query_limit.or(ingest_limit)
             }
             _ => None,
         }

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -5,14 +5,12 @@ use http::header;
 use std::fmt::Display;
 use thiserror::Error;
 
+pub(crate) const STATUS_QUERY_LIMIT_EXCEEDED: u16 = 430;
 pub(crate) const HEADER_QUERY_LIMIT: &str = "X-QueryLimit-Limit";
 pub(crate) const HEADER_QUERY_REMAINING: &str = "X-QueryLimit-Remaining";
 pub(crate) const HEADER_QUERY_RESET: &str = "X-QueryLimit-Reset";
 
-pub(crate) const HEADER_INGEST_LIMIT: &str = "X-IngestLimit-Limit";
-pub(crate) const HEADER_INGEST_REMAINING: &str = "X-IngestLimit-Remaining";
-pub(crate) const HEADER_INGEST_RESET: &str = "X-IngestLimit-Reset";
-
+pub(crate) const STATUS_RATE_LIMIT_EXCEEDED: u16 = 429;
 pub(crate) const HEADER_RATE_SCOPE: &str = "X-RateLimit-Scope";
 pub(crate) const HEADER_RATE_LIMIT: &str = "X-RateLimit-Limit";
 pub(crate) const HEADER_RATE_REMAINING: &str = "X-RateLimit-Remaining";
@@ -31,55 +29,42 @@ pub(crate) enum InvalidHeaderError {
 #[derive(Debug, Clone)]
 pub(crate) enum Limit {
     Query(Limits),
-    Ingest(Limits),
     Rate(String, Limits),
 }
 
 impl Limit {
-    pub(crate) fn into_inner(self) -> Limits {
-        match self {
-            Limit::Query(l) => l,
-            Limit::Ingest(l) => l,
-            Limit::Rate(_, l) => l,
-        }
-    }
-
     pub(crate) fn try_from(response: &reqwest::Response) -> Option<Self> {
-        let path = response.url().path();
-        if path.ends_with("/ingest") {
-            Limits::from_headers(
-                response.headers(),
-                HEADER_INGEST_LIMIT,
-                HEADER_INGEST_REMAINING,
-                HEADER_INGEST_RESET,
-            )
-            .map(Limit::Ingest)
-            .ok()
-        } else if path.ends_with("/query") || path.ends_with("/_apl") {
-            Limits::from_headers(
-                response.headers(),
-                HEADER_QUERY_LIMIT,
-                HEADER_QUERY_REMAINING,
-                HEADER_QUERY_RESET,
-            )
-            .map(Limit::Query)
-            .ok()
-        } else {
-            let scope = response
-                .headers()
-                .get(HEADER_RATE_SCOPE)
-                .and_then(|limit| limit.to_str().ok());
-            let limits = Limits::from_headers(
-                response.headers(),
-                HEADER_RATE_LIMIT,
-                HEADER_RATE_REMAINING,
-                HEADER_RATE_RESET,
-            )
-            .ok();
+        match response.status().as_u16() {
+            STATUS_RATE_LIMIT_EXCEEDED => {
+                // Rate limit
+                let scope = response
+                    .headers()
+                    .get(HEADER_RATE_SCOPE)
+                    .and_then(|limit| limit.to_str().ok());
+                let limits = Limits::from_headers(
+                    response.headers(),
+                    HEADER_RATE_LIMIT,
+                    HEADER_RATE_REMAINING,
+                    HEADER_RATE_RESET,
+                )
+                .ok();
 
-            scope
-                .zip(limits)
-                .map(|(scope, limits)| Limit::Rate(scope.to_string(), limits))
+                scope
+                    .zip(limits)
+                    .map(|(scope, limits)| Limit::Rate(scope.to_string(), limits))
+            }
+            STATUS_QUERY_LIMIT_EXCEEDED => {
+                // Query limit
+                Limits::from_headers(
+                    response.headers(),
+                    HEADER_QUERY_LIMIT,
+                    HEADER_QUERY_REMAINING,
+                    HEADER_QUERY_RESET,
+                )
+                .map(Limit::Query)
+                .ok()
+            }
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
There's no ingest rate limit anymore and we don't need to store the limits on the client. Also the query limit is returned with a 430.