### PR TITLE
Add simple apl builder

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -22,7 +22,9 @@ use crate::{
     },
     error::{Error, Result},
     http::{self, HeaderMap},
-    is_personal_token, users,
+    is_personal_token,
+    query_builder::{QueryBuilder, StateInitial, StatefulQueryBuilder},
+    users,
 };
 
 /// API URL is the URL for the Axiom Cloud API.
@@ -80,6 +82,11 @@ impl Client {
     /// Get client version.
     pub async fn version(&self) -> String {
         env!("CARGO_PKG_VERSION").to_string()
+    }
+
+    /// Get an APL query builder for the given dataset.
+    pub fn apl_builder(dataset_name: impl Into<String>) -> StatefulQueryBuilder<StateInitial> {
+        QueryBuilder::new(dataset_name)
     }
 
     /// Executes the given query specified using the Axiom Processing Language (APL).

--- a/src/client.rs
+++ b/src/client.rs
@@ -83,7 +83,7 @@ impl Client {
     }
 
     /// Executes the given query specified using the Axiom Processing Language (APL).
-    /// To learn more about APL, see the APL documentation at https://www.axiom.co/docs/apl/introduction.
+    /// To learn more about APL, see the APL documentation at <https://www.axiom.co/docs/apl/introduction>.
     #[instrument(skip(self, opts))]
     pub async fn query<S, O>(&self, apl: S, opts: O) -> Result<QueryResult>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod client;
 pub mod error;
 mod http;
 pub mod limits;
+pub mod query_builder;
 mod serde;
 
 pub mod datasets;

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -70,6 +70,7 @@ pub struct QueryBuilder {}
 
 impl QueryBuilder {
     /// Create a new query builder for the given dataset.
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(dataset_name: impl Into<String>) -> StatefulQueryBuilder<StateInitial> {
         StatefulQueryBuilder {
             dataset_name: dataset_name.into(),

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -352,8 +352,8 @@ mod tests {
             .r#where("name == 'John'")
             .and("age == 30")
             .or("age == 40")
-            .extend("height = 84")
-            .project(vec!["weight = 78", "foo = 'bar'"])
+            .extend(vec!["height = 84", "isYoung = age < 30"])
+            .project("weight = 78")
             .take(10)
             .summarize("avg(price)")
             .by(vec!["bin_auto(_time)", "customer_name"])
@@ -363,9 +363,9 @@ mod tests {
         assert_eq!(
             query,
             r#"['users']
-| where ['name'] == 'John' and ['age'] == 30 or ['age'] == 40
-| extend ['height'] = 84, ['isOld'] = age > 30
-| project ['weight'] = 78
+| where name == 'John' and age == 30 or age == 40
+| extend height = 84, isYoung = age < 30
+| project weight = 78
 | take 10
 | summarize avg(price) by bin_auto(_time), customer_name
 | count"#

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -2,6 +2,7 @@
 //!
 //! # Examples
 //! ```
+//! use axiom_rs::query_builder::QueryBuilder;
 //! let query = QueryBuilder::new("my-dataset")
 //!    .r#where("foo == 'bar'")
 //!    .extend("baz = 1")
@@ -101,10 +102,13 @@ impl<State> StatefulQueryBuilder<State> {
     ///
     /// # Examples
     /// ```
+    /// use axiom_rs::query_builder::QueryBuilder;
+    ///
     /// let query = QueryBuilder::new("my-dataset")
     ///     .r#where("foo == 'bar'")
     ///     .to_string();
-    /// assert_eq!(query, r#"['my-dataset'] | where foo == 'bar'"#);
+    /// assert_eq!(query, r#"['my-dataset']
+    /// | where foo == 'bar'"#);
     /// ```
     pub fn r#where(mut self, expr: impl Into<String>) -> StatefulQueryBuilder<StateWhere> {
         self.statements.push(Statement::Where(expr.into()));
@@ -119,10 +123,13 @@ impl<State> StatefulQueryBuilder<State> {
     ///
     /// # Examples
     /// ```
+    /// use axiom_rs::query_builder::QueryBuilder;
+    ///
     /// let query = QueryBuilder::new("my-dataset")
     ///     .extend("foo = 'bar'")
     ///     .to_string();
-    /// assert_eq!(query, r#"['my-dataset'] | extend foo = 'bar'"#);
+    /// assert_eq!(query, r#"['my-dataset']
+    /// | extend foo = 'bar'"#);
     /// ```
     pub fn extend(mut self, expr: impl StringOrVec) -> StatefulQueryBuilder<StateInitial> {
         self.statements.push(Statement::Extend(expr.into_vec()));
@@ -137,10 +144,13 @@ impl<State> StatefulQueryBuilder<State> {
     ///
     /// # Examples
     /// ```
+    /// use axiom_rs::query_builder::QueryBuilder;
+    ///
     /// let query = QueryBuilder::new("my-dataset")
     ///     .project("foo = 'bar'")
     ///     .to_string();
-    /// assert_eq!(query, r#"['my-dataset'] | project foo = 'bar'"#);
+    /// assert_eq!(query, r#"['my-dataset']
+    /// | project foo = 'bar'"#);
     /// ```
     pub fn project(mut self, expr: impl StringOrVec) -> StatefulQueryBuilder<StateInitial> {
         self.statements.push(Statement::Project(expr.into_vec()));
@@ -155,8 +165,11 @@ impl<State> StatefulQueryBuilder<State> {
     ///
     /// # Examples
     /// ```
+    /// use axiom_rs::query_builder::QueryBuilder;
+    ///
     /// let query = QueryBuilder::new("my-dataset").take(10).to_string();
-    /// assert_eq!(query, r#"['my-dataset'] | take 10"#);
+    /// assert_eq!(query, r#"['my-dataset']
+    /// | take 10"#);
     /// ```
     pub fn take(mut self, count: impl Into<i64>) -> StatefulQueryBuilder<StateInitial> {
         self.statements.push(Statement::Take(count.into()));
@@ -173,10 +186,13 @@ impl<State> StatefulQueryBuilder<State> {
     ///
     /// # Examples
     /// ```
+    /// use axiom_rs::query_builder::QueryBuilder;
+    ///
     /// let query = QueryBuilder::new("my-dataset")
     ///     .summarize("count()")
     ///     .to_string();
-    /// assert_eq!(query, r#"['my-dataset'] | summarize count()"#);
+    /// assert_eq!(query, r#"['my-dataset']
+    /// | summarize count()"#);
     /// ```
     pub fn summarize(mut self, expr: impl Into<String>) -> StatefulQueryBuilder<StateSummarize> {
         self.statements.push(Statement::Summarize(expr.into()));
@@ -191,8 +207,11 @@ impl<State> StatefulQueryBuilder<State> {
     ///
     /// # Examples
     /// ```
+    /// use axiom_rs::query_builder::QueryBuilder;
+    ///
     /// let query = QueryBuilder::new("my-dataset").count().to_string();
-    /// assert_eq!(query, r#"['my-dataset'] | count"#);
+    /// assert_eq!(query, r#"['my-dataset']
+    /// | count"#);
     /// ```
     pub fn count(mut self) -> StatefulQueryBuilder<StateInitial> {
         self.statements.push(Statement::Count);
@@ -248,11 +267,24 @@ where
     ///
     /// # Examples
     /// ```
+    /// use axiom_rs::query_builder::QueryBuilder;
+    ///
     /// let query = QueryBuilder::new("my-dataset")
     ///     .r#where("foo == 'bar'")
     ///     .and("baz == 'qux'")
     ///     .to_string();
-    /// assert_eq!(query, r#"['my-dataset'] | where foo == 'bar' and baz == 'qux'"#);
+    /// assert_eq!(query, r#"['my-dataset']
+    /// | where foo == 'bar' and baz == 'qux'"#);
+    /// ```
+    ///
+    /// Note that you can only run this after a [`StatefulQueryBuilder::where`]
+    /// call, this doesn't work:
+    ///
+    /// ```compile_fail
+    /// use axiom_rs::query_builder::QueryBuilder;
+    ///
+    /// let query = QueryBuilder::new("my-dataset")
+    ///     .and("foo == 'bar'");
     /// ```
     pub fn and(mut self, expr: impl Into<String>) -> Self {
         self.statements.push(Statement::WhereAnd(expr.into()));
@@ -265,11 +297,25 @@ where
     ///
     /// # Examples
     /// ```
+    /// use axiom_rs::query_builder::QueryBuilder;
+    ///
     /// let query = QueryBuilder::new("my-dataset")
     ///     .r#where("foo == 'bar'")
     ///     .or("baz == 'qux'")
     ///     .to_string();
-    /// assert_eq!(query, r#"['my-dataset'] | where foo == 'bar' or baz == 'qux'"#);
+    /// assert_eq!(query, r#"['my-dataset']
+    /// | where foo == 'bar' or baz == 'qux'"#);
+    /// ```
+    ///
+    /// Note that you can only run this after a [`StatefulQueryBuilder::where`]
+    /// call, this doesn't work:
+    ///
+    /// ```compile_fail
+    /// use axiom_rs::query_builder::QueryBuilder;
+    ///
+    /// let query = QueryBuilder::new("my-dataset")
+    ///     .or("foo == 'bar'");
+    /// ```
     pub fn or(mut self, expr: impl Into<String>) -> Self {
         self.statements.push(Statement::WhereOr(expr.into()));
         self
@@ -296,11 +342,24 @@ where
     ///
     /// # Examples
     /// ```
+    /// use axiom_rs::query_builder::QueryBuilder;
+    ///
     /// let query = QueryBuilder::new("my-dataset")
     ///     .summarize("count()")
     ///     .by("foo")
     ///     .to_string();
-    /// assert_eq!(query, r#"['my-dataset'] | summarize count() by foo"#);
+    /// assert_eq!(query, r#"['my-dataset']
+    /// | summarize count() by foo"#);
+    /// ```
+    ///
+    /// Note that you can only run this after a
+    /// [`StatefulQueryBuilder::summarize`] call, this doesn't work:
+    ///
+    /// ```compile_fail
+    /// use axiom_rs::query_builder::QueryBuilder;
+    ///
+    /// let query = QueryBuilder::new("my-dataset")
+    ///     .by("bin_auto(_time)");
     /// ```
     pub fn by(mut self, fields: impl StringOrVec) -> StatefulQueryBuilder<StateInitial> {
         self.statements.push(Statement::By(fields.into_vec()));

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -1,0 +1,358 @@
+//! A simple (experimental) APL query builder.
+//!
+//! # Examples
+//! ```
+//! let query = QueryBuilder::new("my-dataset")
+//!    .r#where("foo == 'bar'")
+//!    .extend("baz = 1")
+//!    .project(vec!["foo", "baz"])
+//!    .take(10)
+//!    .build();
+//! assert_eq!(query, r#"['my-dataset']
+//! | where foo == 'bar'
+//! | extend baz = 1
+//! | project foo, baz
+//! | take 10"#);
+//! ```
+use std::marker::PhantomData;
+
+use crate::Error;
+
+#[derive(Debug)]
+enum Statement {
+    Where(String),
+    WhereAnd(String),
+    WhereOr(String),
+    Extend(Vec<String>),
+    Project(Vec<String>),
+    Take(i64),
+    Summarize(String),
+    By(Vec<String>),
+    Count,
+}
+
+impl std::fmt::Display for Statement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Statement::Where(expr) => {
+                write!(f, "\n| where {}", expr)
+            }
+            Statement::WhereAnd(expr) => {
+                write!(f, " and {}", expr)
+            }
+            Statement::WhereOr(expr) => {
+                write!(f, " or {}", expr)
+            }
+            Statement::Extend(exprs) => {
+                write!(f, "\n| extend {}", exprs.join(", "))
+            }
+            Statement::Project(exprs) => {
+                write!(f, "\n| project {}", exprs.join(", "))
+            }
+            Statement::Take(count) => write!(f, "\n| take {}", count),
+            Statement::Summarize(expr) => {
+                write!(f, "\n| summarize {}", expr)
+            }
+            Statement::By(exprs) => {
+                write!(f, " by {}", exprs.join(", "))
+            }
+            Statement::Count => write!(f, "\n| count"),
+        }
+    }
+}
+
+/// The APL query builder. For query methods, see [`StatefulQueryBuilder`].
+#[derive(Debug)]
+pub struct QueryBuilder {}
+
+impl QueryBuilder {
+    /// Create a new query builder for the given dataset.
+    pub fn new(dataset_name: impl Into<String>) -> StatefulQueryBuilder<StateInitial> {
+        StatefulQueryBuilder {
+            dataset_name: dataset_name.into(),
+            statements: Vec::new(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+/// This is the heart of the APL query builder. It keeps track of what operation
+/// you ran last and allows you to extend it (i.e. chain `where` statements
+/// using `and`/`or`).
+#[derive(Debug)]
+pub struct StatefulQueryBuilder<State> {
+    dataset_name: String,
+    statements: Vec<Statement>,
+    phantom: PhantomData<State>,
+}
+
+/// A marker struct to indicate that the QueryBuilder is in its initial state.
+#[derive(Debug)]
+pub struct StateInitial;
+
+impl<State> StatefulQueryBuilder<State> {
+    /// Add a `where` statement to the query.
+    ///
+    /// See also [`StatefulQueryBuilder::and`] and [`StatefulQueryBuilder::or`].
+    ///
+    /// # Examples
+    /// ```
+    /// let query = QueryBuilder::new("my-dataset")
+    ///     .r#where("foo == 'bar'")
+    ///     .build();
+    /// assert_eq!(query, r#"['my-dataset'] | where foo == 'bar'"#);
+    /// ```
+    pub fn r#where(mut self, expr: impl Into<String>) -> StatefulQueryBuilder<StateWhere> {
+        self.statements.push(Statement::Where(expr.into()));
+        StatefulQueryBuilder::<StateWhere> {
+            dataset_name: self.dataset_name,
+            statements: self.statements,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Add an `extend` statement to the query.
+    ///
+    /// # Examples
+    /// ```
+    /// let query = QueryBuilder::new("my-dataset")
+    ///     .extend("foo = 'bar'")
+    ///     .build();
+    /// assert_eq!(query, r#"['my-dataset'] | extend foo = 'bar'"#);
+    /// ```
+    pub fn extend(mut self, expr: impl StringOrVec) -> StatefulQueryBuilder<StateInitial> {
+        self.statements.push(Statement::Extend(expr.into_vec()));
+        StatefulQueryBuilder::<StateInitial> {
+            dataset_name: self.dataset_name,
+            statements: self.statements,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Add a `project` statement to the query.
+    ///
+    /// # Examples
+    /// ```
+    /// let query = QueryBuilder::new("my-dataset")
+    ///     .project("foo = 'bar'")
+    ///     .build();
+    /// assert_eq!(query, r#"['my-dataset'] | project foo = 'bar'"#);
+    /// ```
+    pub fn project(mut self, expr: impl StringOrVec) -> StatefulQueryBuilder<StateInitial> {
+        self.statements.push(Statement::Project(expr.into_vec()));
+        StatefulQueryBuilder::<StateInitial> {
+            dataset_name: self.dataset_name,
+            statements: self.statements,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Add a `take` statement to the query.
+    ///
+    /// # Examples
+    /// ```
+    /// let query = QueryBuilder::new("my-dataset").take(10).build();
+    /// assert_eq!(query, r#"['my-dataset'] | take 10"#);
+    /// ```
+    pub fn take(mut self, count: impl Into<i64>) -> StatefulQueryBuilder<StateInitial> {
+        self.statements.push(Statement::Take(count.into()));
+        StatefulQueryBuilder::<StateInitial> {
+            dataset_name: self.dataset_name,
+            statements: self.statements,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Add a `summarize` statement to the query.
+    ///
+    /// See also [`StatefulQueryBuilder::by`].
+    ///
+    /// # Examples
+    /// ```
+    /// let query = QueryBuilder::new("my-dataset")
+    ///     .summarize("count()")
+    ///     .build();
+    /// assert_eq!(query, r#"['my-dataset'] | summarize count()"#);
+    /// ```
+    pub fn summarize(mut self, expr: impl Into<String>) -> StatefulQueryBuilder<StateSummarize> {
+        self.statements.push(Statement::Summarize(expr.into()));
+        StatefulQueryBuilder::<StateSummarize> {
+            dataset_name: self.dataset_name,
+            statements: self.statements,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Add a `count` statement to the query.
+    ///
+    /// # Examples
+    /// ```
+    /// let query = QueryBuilder::new("my-dataset").count().build();
+    /// assert_eq!(query, r#"['my-dataset'] | count"#);
+    /// ```
+    pub fn count(mut self) -> StatefulQueryBuilder<StateInitial> {
+        self.statements.push(Statement::Count);
+        StatefulQueryBuilder::<StateInitial> {
+            dataset_name: self.dataset_name,
+            statements: self.statements,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Build the query.
+    pub fn build(self) -> String {
+        format!(
+            "['{}']{}",
+            self.dataset_name,
+            self.statements
+                .into_iter()
+                .map(|stmt| stmt.to_string())
+                .collect::<Vec<_>>()
+                .join("")
+        )
+    }
+}
+
+/// A marker struct to indicate that the QueryBuilder's last statement is `where`.
+#[derive(Debug)]
+pub struct StateWhere;
+
+/// The marker struct for [`StateWhere`].
+pub trait Where {}
+
+impl Where for StateWhere {}
+
+impl<State> StatefulQueryBuilder<State>
+where
+    State: Where,
+{
+    /// Add an `and` statement to the current where statement.
+    ///
+    /// See also [`StatefulQueryBuilder::where`].
+    ///
+    /// # Examples
+    /// ```
+    /// let query = QueryBuilder::new("my-dataset")
+    ///     .r#where("foo == 'bar'")
+    ///     .and("baz == 'qux'")
+    ///     .build();
+    /// assert_eq!(query, r#"['my-dataset'] | where foo == 'bar' and baz == 'qux'"#);
+    /// ```
+    pub fn and(mut self, expr: impl Into<String>) -> Self {
+        self.statements.push(Statement::WhereAnd(expr.into()));
+        self
+    }
+
+    /// Add an `or` statement to the current where statement.
+    ///
+    /// See also [`StatefulQueryBuilder::where`].
+    ///
+    /// # Examples
+    /// ```
+    /// let query = QueryBuilder::new("my-dataset")
+    ///     .r#where("foo == 'bar'")
+    ///     .or("baz == 'qux'")
+    ///     .build();
+    /// assert_eq!(query, r#"['my-dataset'] | where foo == 'bar' or baz == 'qux'"#);
+    pub fn or(mut self, expr: impl Into<String>) -> Self {
+        self.statements.push(Statement::WhereOr(expr.into()));
+        self
+    }
+}
+
+/// A marker struct to indicate that the QueryBuilder's last statement is
+/// `summarize`.
+#[derive(Debug)]
+pub struct StateSummarize;
+
+/// The marker struct for [`StateSummarize`].
+pub trait Summarize {}
+
+impl Summarize for StateSummarize {}
+
+impl<State> StatefulQueryBuilder<State>
+where
+    State: Summarize,
+{
+    /// Add a `by` statement to the current summarize statement.
+    ///
+    /// See also [`StatefulQueryBuilder::summarize`].
+    ///
+    /// # Examples
+    /// ```
+    /// let query = QueryBuilder::new("my-dataset")
+    ///     .summarize("count()")
+    ///     .by("foo")
+    ///     .build();
+    /// assert_eq!(query, r#"['my-dataset'] | summarize count() by foo"#);
+    /// ```
+    pub fn by(mut self, fields: impl StringOrVec) -> StatefulQueryBuilder<StateInitial> {
+        self.statements.push(Statement::By(fields.into_vec()));
+        StatefulQueryBuilder::<StateInitial> {
+            dataset_name: self.dataset_name,
+            statements: self.statements,
+            phantom: PhantomData,
+        }
+    }
+}
+
+/// A trait to convert a string or a vector of strings into a vector of strings.
+/// It's used in methods where we want to accept one or more strings.
+pub trait StringOrVec {
+    fn into_vec(self) -> Vec<String>;
+}
+
+impl StringOrVec for String {
+    fn into_vec(self) -> Vec<String> {
+        vec![self]
+    }
+}
+
+impl StringOrVec for &str {
+    fn into_vec(self) -> Vec<String> {
+        vec![self.to_string()]
+    }
+}
+
+impl StringOrVec for Vec<&str> {
+    fn into_vec(self) -> Vec<String> {
+        self.into_iter().map(|s| s.to_string()).collect()
+    }
+}
+
+impl StringOrVec for Vec<String> {
+    fn into_vec(self) -> Vec<String> {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_query_builder() {
+        let query = QueryBuilder::new("users")
+            .r#where("name == 'John'")
+            .and("age == 30")
+            .or("age == 40")
+            .extend("height = 84")
+            .project(vec!["weight = 78", "foo = 'bar'"])
+            .take(10)
+            .summarize("avg(price)")
+            .by(vec!["bin_auto(_time)", "customer_name"])
+            .count()
+            .build();
+
+        assert_eq!(
+            query,
+            r#"['users']
+| where ['name'] == 'John' and ['age'] == 30 or ['age'] == 40
+| extend ['height'] = 84, ['isOld'] = age > 30
+| project ['weight'] = 78
+| take 10
+| summarize avg(price) by bin_auto(_time), customer_name
+| count"#
+        );
+    }
+}


### PR DESCRIPTION
This adds a simple APL query builder. Example:

```rust
let query = QueryBuilder::new("my-dataset")
    .r#where("foo == 'bar'")
    .and("baz == 'qux'")
    .build();
assert_eq!(query, r#"['my-dataset'] | where foo == 'bar' and baz == 'qux'"#);
```