### PR TITLE
Fix serialization issues for CacheStatus on dataset query response

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ url = "2"
 tracing = { version = "0.1" }
 tokio-stream = "0.1"
 bitflags = "2"
+bitflags_serde_shim = "0.2.4"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/src/datasets/model.rs
+++ b/src/datasets/model.rs
@@ -1,4 +1,5 @@
 use bitflags::bitflags;
+use bitflags_serde_shim::impl_serde_for_bitflags;
 use chrono::{DateTime, Duration, Utc};
 use http::header::HeaderValue;
 use serde::{
@@ -888,25 +889,7 @@ bitflags! {
         const WalCached = 8;    // WAL is cached
     }
 }
-
-impl Serialize for CacheStatus {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_u32((*self).bits())
-    }
-}
-
-impl<'de> Deserialize<'de> for CacheStatus {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value: u32 = Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_bits(value).unwrap_or_default())
-    }
-}
+impl_serde_for_bitflags!(CacheStatus);
 
 /// A message that is returned in the status of a query.
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
Fixes a serialization issue with CacheStatus in dataaset apl queries when cache status
is using a composite value that isn't a valid flag in the rust `CacheStatus` bitflag struct.

The underlying issue was that neither bitflags serializtion ( maps to a string, is not wire
compatible with the axiom API which maps to an int ) not custom serialization work when
the cachestatus is a composite of multiple valid flags.

The resolution is to use an alternate marshalling method that is wire compatible and
represents and interprets the flags correctly.