### PR TITLE
Fix query parameter for saveAsKind

### DIFF
--- a/src/annotations/model.rs
+++ b/src/annotations/model.rs
@@ -5,7 +5,6 @@ use url::Url;
 /// An annotation.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-
 pub struct Annotation {
     /// Unique ID of the annotation
     pub id: String,

--- a/src/client.rs
+++ b/src/client.rs
@@ -100,7 +100,7 @@ impl Client {
 
     /// Get client version.
     #[must_use]
-    pub fn version(&self) -> &str {
+    pub fn version(&self) -> &'static str {
         env!("CARGO_PKG_VERSION")
     }
 
@@ -286,7 +286,6 @@ impl Builder {
 
     /// Add an URL to the client. This is only meant for testing purposes, you
     /// don't need to set it.
-    #[doc(hidden)]
     #[must_use]
     pub fn with_url<S: Into<String>>(mut self, url: S) -> Self {
         self.url = Some(url.into());

--- a/src/http.rs
+++ b/src/http.rs
@@ -179,6 +179,7 @@ impl Client {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct Response {
     inner: reqwest::Response,
     method: http::Method,


### PR DESCRIPTION
the `saveAsKind` parameter was serialized to false instead of omitted 