### PR TITLE
Include trace

### DIFF
--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -63,12 +63,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .await?
                 .into_iter()
                 .for_each(|dataset| {
-                    println!("{:?}", dataset);
+                    println!("{dataset:?}");
                 }),
             Datasets::Get { name } => println!("{:?}", client.datasets().get(&name).await?),
             Datasets::Update { name, description } => {
                 let dataset = client.datasets().update(&name, description).await?;
-                println!("{:?}", dataset);
+                println!("{dataset:?}");
             }
             Datasets::Delete { name } => client.datasets().delete(&name).await?,
             Datasets::Ingest {
@@ -81,7 +81,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let ingest_status = client
                     .ingest_bytes(&name, buf, content_type, content_encoding)
                     .await?;
-                println!("{:?}", ingest_status);
+                println!("{ingest_status:?}");
             }
             Datasets::Query { apl } => {
                 let result = client.query(&apl, None).await?;
@@ -110,14 +110,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let t = rows.table().title(fields).bold(true);
 
                     let table_display = t.display().unwrap();
-                    println!("{}", table_display);
+                    println!("{table_display}",);
                 }
             }
         },
         Opt::Users(users) => match users {
             Users::Current => {
                 let user = client.users().current().await?;
-                println!("{:?}", user);
+                println!("{user:?}");
             }
         },
     };

--- a/examples/ingest-hn.rs
+++ b/examples/ingest-hn.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .try_init()?;
 
     let dataset_name = env::var("DATASET_NAME").expect("Missing DATASET_NAME");
-    let max_item_id = reqwest::get(format!("{}/v0/maxitem.json", BASE_URL))
+    let max_item_id = reqwest::get(format!("{BASE_URL}/v0/maxitem.json"))
         .await?
         .text()
         .await?
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let stream = stream::iter(0..max_item_id)
         .map(|id| async move {
             info!(?id, "Fetching item");
-            reqwest::get(format!("{}/v0/item/{}.json", BASE_URL, id))
+            reqwest::get(format!("{BASE_URL}/v0/item/{id}.json"))
                 .await?
                 .json::<JsonValue>()
                 .await

--- a/src/client.rs
+++ b/src/client.rs
@@ -138,10 +138,18 @@ impl Client {
             .map(|s| s.to_str())
             .transpose()
             .map_err(|_e| Error::InvalidQueryId)?
-            .map(std::string::ToString::to_string);
+            .map(ToString::to_string);
 
+        let trace_id = resp
+            .headers()
+            .get("x-axiom-trace-id")
+            .map(|s| s.to_str())
+            .transpose()
+            .map_err(|_e| Error::InvalidTraceId)?
+            .map(ToString::to_string);
         let mut result = resp.json::<QueryResult>().await?;
         result.saved_query_id = saved_query_id;
+        result.trace_id = trace_id;
 
         Ok(result)
     }

--- a/src/datasets/model.rs
+++ b/src/datasets/model.rs
@@ -617,6 +617,9 @@ pub struct QueryResult {
     /// option specified.
     #[serde(skip)]
     pub saved_query_id: Option<String>,
+    /// OTel-Trace-ID of the query executuion. Used for error reporting and debugging.
+    #[serde(skip)]
+    pub trace_id: Option<String>,
 }
 
 /// The status of a query result.

--- a/src/datasets/model.rs
+++ b/src/datasets/model.rs
@@ -617,7 +617,7 @@ pub struct QueryResult {
     /// option specified.
     #[serde(skip)]
     pub saved_query_id: Option<String>,
-    /// OTel-Trace-ID of the query executuion. Used for error reporting and debugging.
+    /// OTel-Trace-ID of the query execution. Used for error reporting and debugging.
     #[serde(skip)]
     pub trace_id: Option<String>,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,6 +51,9 @@ pub enum Error {
     #[error("Query ID contains invisible characters (this is a server error)")]
     /// Query ID contains invisible characters (this is a server error).
     InvalidQueryId,
+    #[error("Trace ID contains invisible characters (this is a server error)")]
+    /// Query ID contains invisible characters (this is a server error).
+    InvalidTraceId,
     #[error(transparent)]
     /// Invalid Query Parameters.
     InvalidParams(#[from] serde_qs::Error),


### PR DESCRIPTION
It can be helpful to have a access to the trace-id the API returns, this Pr exposes it as part of the result