### PR TITLE
feat: Add `Client.ingest_bytes_opt`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axiom-rs"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["Arne Bahlo <arne@axiom.co>"]
 edition = "2018"
 rust-version = "1.60"


### PR DESCRIPTION
This method is like `ingest_bytes`, but takes an additional parameter called `RequestOptions`.
This struct can contain additional headers to add to the ingest request.

This also bumps the version to 0.11.3.