### PR TITLE
feat: dashboards (v2), metrics (info/tags/MPL), and missing query-metrics ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,43 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+### Metrics and dashboards
+
+In addition to events (datasets / APL), `axiom-rs` exposes the
+metrics-info, MPL query, and `v2` dashboards APIs:
+
+```rust,no_run
+use axiom_rs::{metrics::MplQueryOptions, Client};
+use chrono::{Duration, Utc};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new()?;
+    let end = Utc::now();
+    let start = end - Duration::hours(1);
+
+    // Discover metrics in a dataset.
+    let info = client.metrics().list("my-metrics-dataset", start, end).await?;
+    for (name, meta) in &info {
+        println!("{name}\t{:?}", meta.kind);
+    }
+
+    // Run an MPL query.
+    let res = client
+        .metrics()
+        .query("metric('http_requests_total')", start, end, MplQueryOptions::default())
+        .await?;
+    println!("{} series, trace = {:?}", res.series.len(), res.trace_id);
+
+    // List dashboards.
+    for d in client.dashboards().list().await? {
+        println!("{}\t{}", d.uid, d.name().unwrap_or("(unnamed)"));
+    }
+
+    Ok(())
+}
+```
+
 ## Install
 
 ```sh

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,14 +16,14 @@ use tokio_stream::StreamExt;
 use tracing::instrument;
 
 use crate::{
-    annotations,
+    annotations, dashboards,
     datasets::{
         self, ContentEncoding, ContentType, IngestStatus, Query, QueryOptions, QueryParams,
         QueryResult,
     },
     error::{Error, Result},
     http::{self, HeaderMap},
-    is_personal_token, users,
+    is_personal_token, metrics, users,
 };
 
 /// API URL is the URL for the Axiom Cloud API.
@@ -164,6 +164,19 @@ impl Client {
     #[must_use]
     pub fn annotations(&self) -> annotations::Client<'_> {
         annotations::Client::new(&self.api_http)
+    }
+
+    /// Returns a client for working with dashboards (`v2` API).
+    #[must_use]
+    pub fn dashboards(&self) -> dashboards::Client<'_> {
+        dashboards::Client::new(&self.api_http)
+    }
+
+    /// Returns a client for working with metrics — metric discovery, tags,
+    /// tag values, and MPL queries — against the edge URL.
+    #[must_use]
+    pub fn metrics(&self) -> metrics::Client<'_> {
+        metrics::Client::new(&self.edge_http)
     }
 
     /// Get the API url

--- a/src/dashboards.rs
+++ b/src/dashboards.rs
@@ -27,10 +27,11 @@
 //! ```
 mod client;
 mod model;
+#[cfg(test)]
 mod tests;
 
 pub use client::Client;
 pub use model::{
-    Chart, ChartBase, Dashboard, DashboardDocument, DashboardWriteResponse, DashboardWriteStatus,
-    LayoutItem, UpsertRequest,
+    Chart, ChartBase, CreateOptions, Dashboard, DashboardDocument, DashboardWriteResponse,
+    DashboardWriteStatus, KnownChart, LayoutItem, UpsertOptions, UpsertRequest,
 };

--- a/src/dashboards.rs
+++ b/src/dashboards.rs
@@ -1,0 +1,36 @@
+//! Create, read, update, and delete Axiom dashboards.
+//!
+//! You're probably looking for the [`Client`].
+//!
+//! # Examples
+//! ```no_run
+//! use axiom_rs::{Client, Error};
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Error> {
+//!     let client = Client::new()?;
+//!
+//!     // Fetch every dashboard the token can see.
+//!     let dashboards = client.dashboards().list().await?;
+//!     for d in &dashboards {
+//!         println!("{}\t{}", d.uid, d.name().unwrap_or("(unnamed)"));
+//!     }
+//!
+//!     // Load a single dashboard by uid.
+//!     if let Some(first) = dashboards.first() {
+//!         let dashboard = client.dashboards().get(&first.uid).await?;
+//!         println!("loaded version {:?}", dashboard.version);
+//!     }
+//!
+//!     Ok(())
+//! }
+//! ```
+mod client;
+mod model;
+mod tests;
+
+pub use client::Client;
+pub use model::{
+    Chart, ChartBase, Dashboard, DashboardDocument, DashboardWriteResponse, DashboardWriteStatus,
+    LayoutItem, UpsertRequest,
+};

--- a/src/dashboards/client.rs
+++ b/src/dashboards/client.rs
@@ -1,11 +1,25 @@
 use std::fmt::Debug as FmtDebug;
+use serde::Serialize;
 use tracing::instrument;
 
 use crate::{
-    dashboards::model::{Dashboard, DashboardDocument, DashboardWriteResponse, UpsertRequest},
+    dashboards::model::{
+        CreateOptions, Dashboard, DashboardDocument, DashboardWriteResponse, UpsertOptions,
+        UpsertRequest,
+    },
     error::{Axiom, Error, Result},
     http,
 };
+
+/// Server's maximum page size for `GET /v2/dashboards`.
+const LIST_LIMIT: u32 = 1000;
+
+/// Query string for the dashboards list endpoint. Round-tripped through
+/// `serde_qs` for consistency with the rest of the SDK.
+#[derive(Serialize)]
+struct ListParams {
+    limit: u32,
+}
 
 /// Provides methods to work with Axiom dashboards (`v2` API).
 ///
@@ -33,8 +47,9 @@ impl<'client> Client<'client> {
     /// deserialised.
     #[instrument(skip(self))]
     pub async fn list(&self) -> Result<Vec<Dashboard>> {
+        let qs = serde_qs::to_string(&ListParams { limit: LIST_LIMIT })?;
         self.http_client
-            .get("/v2/dashboards?limit=1000")
+            .get(format!("/v2/dashboards?{qs}"))
             .await?
             .json()
             .await
@@ -46,10 +61,7 @@ impl<'client> Client<'client> {
     /// Returns an error if the HTTP request fails or the response cannot be
     /// deserialised.
     #[instrument(skip(self))]
-    pub async fn get<U>(&self, uid: U) -> Result<Dashboard>
-    where
-        U: Into<String> + FmtDebug,
-    {
+    pub async fn get(&self, uid: impl Into<String> + FmtDebug) -> Result<Dashboard> {
         let uid = uid.into();
         self.http_client
             .get(format!("/v2/dashboards/uid/{uid}"))
@@ -60,64 +72,81 @@ impl<'client> Client<'client> {
 
     /// Create a new dashboard.
     ///
-    /// `uid` is optional; when omitted the server assigns one derived from
-    /// the dashboard's name.
+    /// Pass [`CreateOptions::default()`] (or `None`) for the common case;
+    /// supply a `uid` to request a specific one (otherwise the server
+    /// assigns one derived from the dashboard's name) and/or a `message`
+    /// for the audit log.
     ///
     /// # Errors
     /// Returns an error if the HTTP request fails, the response cannot be
-    /// deserialised, or the server reports an error.
-    #[instrument(skip(self, doc))]
-    pub async fn create(
+    /// deserialised, or the server reports an error. See
+    /// [`Error::DashboardVersionConflict`] for the optimistic-concurrency
+    /// failure mode (`put` only).
+    #[instrument(skip(self, doc, opts))]
+    pub async fn create<O>(
         &self,
         doc: &DashboardDocument,
-        uid: Option<&str>,
-        message: Option<&str>,
-    ) -> Result<DashboardWriteResponse> {
+        opts: O,
+    ) -> Result<DashboardWriteResponse>
+    where
+        O: Into<Option<CreateOptions>>,
+    {
+        let opts = opts.into().unwrap_or_default();
         let body = UpsertRequest {
             dashboard: doc,
             version: None,
             overwrite: false,
-            uid,
-            message,
+            uid: opts.uid.as_deref(),
+            message: opts.message.as_deref(),
         };
         let resp = self.http_client.post("/v2/dashboards", body).await?;
-        decode_write_response(resp, ::http::Method::POST, "/v2/dashboards".to_string()).await
+        // `create` cannot raise an optimistic-version conflict (there's no
+        // prior version), so a 412 here would be just as unexpected as on
+        // any other write; passing the (optional) caller-supplied uid is
+        // harmless and keeps the helper uniform.
+        decode_write_response(resp, opts.uid.as_deref().unwrap_or("")).await
     }
 
     /// Replace an existing dashboard, addressing it by `uid`.
     ///
-    /// `expected_version` is the version you loaded; pass it unless
-    /// `overwrite` is `true`, in which case the server skips the version
-    /// check. A version mismatch surfaces as
+    /// Pass [`UpsertOptions::default()`] (or `None`) for a write with the
+    /// server's default version-check policy. Set
+    /// [`UpsertOptions::expected_version`] to the version you loaded for
+    /// strict optimistic concurrency, or [`UpsertOptions::overwrite`] to
+    /// skip the check. A version mismatch surfaces as
     /// [`Error::DashboardVersionConflict`] populated with the server's
     /// current version.
     ///
     /// # Errors
     /// Returns an error if the HTTP request fails, the response cannot be
-    /// deserialised, or the server reports an error.
-    #[instrument(skip(self, doc))]
-    pub async fn put<U>(
+    /// deserialised, the server reports an error, or the optimistic version
+    /// check fails (see [`Error::DashboardVersionConflict`]).
+    #[instrument(skip(self, doc, opts))]
+    pub async fn put<O>(
         &self,
-        uid: U,
+        uid: impl Into<String> + FmtDebug,
         doc: &DashboardDocument,
-        expected_version: Option<i64>,
-        overwrite: bool,
-        message: Option<&str>,
+        opts: O,
     ) -> Result<DashboardWriteResponse>
     where
-        U: Into<String> + FmtDebug,
+        O: Into<Option<UpsertOptions>>,
     {
         let uid = uid.into();
+        let opts = opts.into().unwrap_or_default();
         let path = format!("/v2/dashboards/uid/{uid}");
         let body = UpsertRequest {
             dashboard: doc,
-            version: if overwrite { None } else { expected_version },
-            overwrite,
+            version: if opts.overwrite {
+                None
+            } else {
+                opts.expected_version
+            },
+            overwrite: opts.overwrite,
             uid: Some(&uid),
-            message,
+            message: opts.message.as_deref(),
         };
         let resp = self.http_client.put(&path, body).await?;
-        decode_write_response(resp, ::http::Method::PUT, path).await
+        decode_write_response(resp, &uid).await
     }
 
     /// Delete a dashboard by `uid`.
@@ -126,10 +155,7 @@ impl<'client> Client<'client> {
     /// Returns an error if the HTTP request fails or the server reports an
     /// error.
     #[instrument(skip(self))]
-    pub async fn delete<U>(&self, uid: U) -> Result<()>
-    where
-        U: Into<String> + FmtDebug,
-    {
+    pub async fn delete(&self, uid: impl Into<String> + FmtDebug) -> Result<()> {
         let uid = uid.into();
         self.http_client
             .delete(format!("/v2/dashboards/uid/{uid}"))
@@ -137,41 +163,56 @@ impl<'client> Client<'client> {
     }
 }
 
-/// Decode the write response, mapping `412` to a typed
-/// [`Error::DashboardVersionConflict`] using the dashboard error envelope
-/// (which carries `currentVersion`).
+/// Decode the write response.
+///
+/// Happy path: deserialise the [`DashboardWriteResponse`] envelope via the
+/// shared `check_error` path so rate-limit / query-limit / ingest-limit
+/// mapping all keep working.
+///
+/// 412 conflict: read the raw body so we can extract `currentVersion` and
+/// surface a typed [`Error::DashboardVersionConflict`]. If the body lacks
+/// `currentVersion` (or doesn't decode), fall back to the generic
+/// [`Error::Axiom`] envelope rather than panicking on the decode.
+///
+/// `caller_uid` is the uid the SDK sent in the request, used as the
+/// fallback when the server's error body omits its own `uid` echo.
 async fn decode_write_response(
     resp: http::Response,
-    method: ::http::Method,
-    path: String,
+    caller_uid: &str,
 ) -> Result<DashboardWriteResponse> {
-    let inner: reqwest::Response = resp.into();
-    let status = inner.status();
-    let trace_id = inner
+    if resp.status() != ::http::StatusCode::PRECONDITION_FAILED {
+        return resp.json::<DashboardWriteResponse>().await;
+    }
+
+    // Capture metadata we'll need to build either error variant before
+    // consuming the body.
+    let status = resp.status().as_u16();
+    let method = resp.method().clone();
+    let path = resp.path().to_string();
+    let trace_id = resp
         .headers()
         .get("x-axiom-trace-id")
         .and_then(|v| v.to_str().ok())
         .map(ToString::to_string);
-    let text = inner.text().await.map_err(Error::Http)?;
+    let body = resp.body_text_unchecked().await?;
+    let parsed = serde_json::from_str::<DashboardErrorBody>(&body).ok();
 
-    if status.is_success() {
-        return serde_json::from_str::<DashboardWriteResponse>(&text).map_err(Error::from);
-    }
-
-    let err = serde_json::from_str::<DashboardErrorBody>(&text).ok();
-    if status.as_u16() == 412 {
-        if let Some(current) = err.as_ref().and_then(|e| e.current_version) {
-            return Err(Error::DashboardVersionConflict {
-                uid: err.as_ref().and_then(|e| e.uid.clone()).unwrap_or_default(),
-                current,
-            });
+    if let Some(err) = parsed.as_ref() {
+        if let Some(current) = err.current_version {
+            let uid = err
+                .uid
+                .clone()
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| caller_uid.to_string());
+            return Err(Error::DashboardVersionConflict { uid, current });
         }
     }
+
     Err(Error::Axiom(Axiom::new(
-        status.as_u16(),
+        status,
         method,
         path,
-        err.and_then(|e| {
+        parsed.and_then(|e| {
             if e.message.is_empty() {
                 None
             } else {

--- a/src/dashboards/client.rs
+++ b/src/dashboards/client.rs
@@ -1,5 +1,5 @@
-use std::fmt::Debug as FmtDebug;
 use serde::Serialize;
+use std::fmt::Debug as FmtDebug;
 use tracing::instrument;
 
 use crate::{

--- a/src/dashboards/client.rs
+++ b/src/dashboards/client.rs
@@ -1,0 +1,193 @@
+use std::fmt::Debug as FmtDebug;
+use tracing::instrument;
+
+use crate::{
+    dashboards::model::{Dashboard, DashboardDocument, DashboardWriteResponse, UpsertRequest},
+    error::{Axiom, Error, Result},
+    http,
+};
+
+/// Provides methods to work with Axiom dashboards (`v2` API).
+///
+/// Obtain an instance via [`crate::Client::dashboards`]. All methods hit the
+/// control-plane URL configured on the parent client.
+#[derive(Debug, Clone)]
+pub struct Client<'client> {
+    http_client: &'client http::Client,
+}
+
+impl<'client> Client<'client> {
+    pub(crate) fn new(http_client: &'client http::Client) -> Self {
+        Self { http_client }
+    }
+
+    /// List the dashboards visible to the token, capped at the server's
+    /// maximum page size (1000).
+    ///
+    /// When authenticated with an API token, the server only returns
+    /// dashboards shared org-wide or with a group; private dashboards are
+    /// invisible to API tokens.
+    ///
+    /// # Errors
+    /// Returns an error if the HTTP request fails or the response cannot be
+    /// deserialised.
+    #[instrument(skip(self))]
+    pub async fn list(&self) -> Result<Vec<Dashboard>> {
+        self.http_client
+            .get("/v2/dashboards?limit=1000")
+            .await?
+            .json()
+            .await
+    }
+
+    /// Fetch a single dashboard by its `uid`.
+    ///
+    /// # Errors
+    /// Returns an error if the HTTP request fails or the response cannot be
+    /// deserialised.
+    #[instrument(skip(self))]
+    pub async fn get<U>(&self, uid: U) -> Result<Dashboard>
+    where
+        U: Into<String> + FmtDebug,
+    {
+        let uid = uid.into();
+        self.http_client
+            .get(format!("/v2/dashboards/uid/{uid}"))
+            .await?
+            .json()
+            .await
+    }
+
+    /// Create a new dashboard.
+    ///
+    /// `uid` is optional; when omitted the server assigns one derived from
+    /// the dashboard's name.
+    ///
+    /// # Errors
+    /// Returns an error if the HTTP request fails, the response cannot be
+    /// deserialised, or the server reports an error.
+    #[instrument(skip(self, doc))]
+    pub async fn create(
+        &self,
+        doc: &DashboardDocument,
+        uid: Option<&str>,
+        message: Option<&str>,
+    ) -> Result<DashboardWriteResponse> {
+        let body = UpsertRequest {
+            dashboard: doc,
+            version: None,
+            overwrite: false,
+            uid,
+            message,
+        };
+        let resp = self.http_client.post("/v2/dashboards", body).await?;
+        decode_write_response(resp, ::http::Method::POST, "/v2/dashboards".to_string()).await
+    }
+
+    /// Replace an existing dashboard, addressing it by `uid`.
+    ///
+    /// `expected_version` is the version you loaded; pass it unless
+    /// `overwrite` is `true`, in which case the server skips the version
+    /// check. A version mismatch surfaces as
+    /// [`Error::DashboardVersionConflict`] populated with the server's
+    /// current version.
+    ///
+    /// # Errors
+    /// Returns an error if the HTTP request fails, the response cannot be
+    /// deserialised, or the server reports an error.
+    #[instrument(skip(self, doc))]
+    pub async fn put<U>(
+        &self,
+        uid: U,
+        doc: &DashboardDocument,
+        expected_version: Option<i64>,
+        overwrite: bool,
+        message: Option<&str>,
+    ) -> Result<DashboardWriteResponse>
+    where
+        U: Into<String> + FmtDebug,
+    {
+        let uid = uid.into();
+        let path = format!("/v2/dashboards/uid/{uid}");
+        let body = UpsertRequest {
+            dashboard: doc,
+            version: if overwrite { None } else { expected_version },
+            overwrite,
+            uid: Some(&uid),
+            message,
+        };
+        let resp = self.http_client.put(&path, body).await?;
+        decode_write_response(resp, ::http::Method::PUT, path).await
+    }
+
+    /// Delete a dashboard by `uid`.
+    ///
+    /// # Errors
+    /// Returns an error if the HTTP request fails or the server reports an
+    /// error.
+    #[instrument(skip(self))]
+    pub async fn delete<U>(&self, uid: U) -> Result<()>
+    where
+        U: Into<String> + FmtDebug,
+    {
+        let uid = uid.into();
+        self.http_client
+            .delete(format!("/v2/dashboards/uid/{uid}"))
+            .await
+    }
+}
+
+/// Decode the write response, mapping `412` to a typed
+/// [`Error::DashboardVersionConflict`] using the dashboard error envelope
+/// (which carries `currentVersion`).
+async fn decode_write_response(
+    resp: http::Response,
+    method: ::http::Method,
+    path: String,
+) -> Result<DashboardWriteResponse> {
+    let inner: reqwest::Response = resp.into();
+    let status = inner.status();
+    let trace_id = inner
+        .headers()
+        .get("x-axiom-trace-id")
+        .and_then(|v| v.to_str().ok())
+        .map(ToString::to_string);
+    let text = inner.text().await.map_err(Error::Http)?;
+
+    if status.is_success() {
+        return serde_json::from_str::<DashboardWriteResponse>(&text).map_err(Error::from);
+    }
+
+    let err = serde_json::from_str::<DashboardErrorBody>(&text).ok();
+    if status.as_u16() == 412 {
+        if let Some(current) = err.as_ref().and_then(|e| e.current_version) {
+            return Err(Error::DashboardVersionConflict {
+                uid: err.as_ref().and_then(|e| e.uid.clone()).unwrap_or_default(),
+                current,
+            });
+        }
+    }
+    Err(Error::Axiom(Axiom::new(
+        status.as_u16(),
+        method,
+        path,
+        err.and_then(|e| {
+            if e.message.is_empty() {
+                None
+            } else {
+                Some(e.message)
+            }
+        }),
+        trace_id,
+    )))
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct DashboardErrorBody {
+    #[serde(default)]
+    message: String,
+    #[serde(rename = "currentVersion", default)]
+    current_version: Option<i64>,
+    #[serde(default)]
+    uid: Option<String>,
+}

--- a/src/dashboards/model.rs
+++ b/src/dashboards/model.rs
@@ -56,6 +56,38 @@ impl Dashboard {
     }
 }
 
+/// Per-call options for [`Client::create`].
+///
+/// [`Client::create`]: super::Client::create
+#[derive(Debug, Default, Clone)]
+#[must_use]
+pub struct CreateOptions {
+    /// Desired `uid`. When `None` the server assigns one derived from the
+    /// dashboard's name.
+    pub uid: Option<String>,
+    /// Free-form description of the change, persisted as audit metadata.
+    pub message: Option<String>,
+}
+
+/// Per-call options for [`Client::put`].
+///
+/// [`Client::put`]: super::Client::put
+#[derive(Debug, Default, Clone)]
+#[must_use]
+pub struct UpsertOptions {
+    /// Expected current version on the server (optimistic concurrency).
+    /// Ignored when `overwrite` is `true`. When both `expected_version`
+    /// and `overwrite` are unset, the server applies its default
+    /// version-check policy.
+    pub expected_version: Option<i64>,
+    /// Skip the optimistic version check entirely. Mutually exclusive
+    /// with `expected_version`; set this when you intend to clobber the
+    /// server's current revision.
+    pub overwrite: bool,
+    /// Free-form description of the change, persisted as audit metadata.
+    pub message: Option<String>,
+}
+
 /// Body of a dashboard create or update request.
 ///
 /// Use [`Client::create`] or [`Client::put`] rather than building this
@@ -73,7 +105,7 @@ pub struct UpsertRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<i64>,
     /// When `true`, the server skips the version check entirely.
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub overwrite: bool,
     /// Desired `uid`. Optional on create; the helper sets it for `PUT`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -81,11 +113,6 @@ pub struct UpsertRequest<'a> {
     /// Free-form description of the change, persisted as audit metadata.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<&'a str>,
-}
-
-#[allow(clippy::trivially_copy_pass_by_ref)]
-fn is_false(b: &bool) -> bool {
-    !*b
 }
 
 /// Response envelope shared by `POST /v2/dashboards` and
@@ -155,11 +182,26 @@ pub struct DashboardDocument {
 
 /// One chart on a dashboard.
 ///
-/// Each variant carries the shared [`ChartBase`] fields plus any
-/// chart-specific keys preserved verbatim in [`ChartBase::extras`].
+/// The wire payload is `untagged` at this level: serde tries the typed
+/// [`KnownChart`] decode first, and falls back to [`Chart::Unknown`] for
+/// chart types the SDK doesn't yet know about. The fallback preserves the
+/// raw JSON verbatim so `get` → `put` round-trips don't drop server-side
+/// fields the SDK pre-dates.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum Chart {
+    /// One of the chart variants the SDK models explicitly.
+    Known(KnownChart),
+    /// A chart variant the SDK doesn't model. Held as raw JSON so it
+    /// round-trips cleanly through `put`.
+    Unknown(serde_json::Value),
+}
+
+/// Chart variants the SDK models explicitly. The wire discriminator is
+/// the `type` field on each variant.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "type")]
-pub enum Chart {
+pub enum KnownChart {
     /// Time-series line/area chart.
     TimeSeries(ChartBase),
     /// Heatmap chart.
@@ -181,19 +223,52 @@ pub enum Chart {
 }
 
 impl Chart {
+    /// Borrow the shared chart fields, when the variant is known.
+    /// Returns `None` for [`Chart::Unknown`].
+    #[must_use]
+    pub fn base(&self) -> Option<&ChartBase> {
+        match self {
+            Chart::Known(k) => Some(k.base()),
+            Chart::Unknown(_) => None,
+        }
+    }
+
+    /// Borrow the shared chart fields mutably, when the variant is known.
+    /// Returns `None` for [`Chart::Unknown`].
+    #[must_use]
+    pub fn base_mut(&mut self) -> Option<&mut ChartBase> {
+        match self {
+            Chart::Known(k) => Some(k.base_mut()),
+            Chart::Unknown(_) => None,
+        }
+    }
+
+    /// Human-readable type name, exactly as it appears on the wire.
+    /// `None` for [`Chart::Unknown`] when the raw JSON doesn't carry a
+    /// string `"type"` field.
+    #[must_use]
+    pub fn type_str(&self) -> Option<&str> {
+        match self {
+            Chart::Known(k) => Some(k.type_str()),
+            Chart::Unknown(v) => v.get("type").and_then(serde_json::Value::as_str),
+        }
+    }
+}
+
+impl KnownChart {
     /// Borrow the shared chart fields regardless of variant.
     #[must_use]
     pub fn base(&self) -> &ChartBase {
         match self {
-            Chart::TimeSeries(b)
-            | Chart::Heatmap(b)
-            | Chart::LogStream(b)
-            | Chart::Pie(b)
-            | Chart::Scatter(b)
-            | Chart::Table(b)
-            | Chart::TopK(b)
-            | Chart::Statistic(b)
-            | Chart::Note(b) => b,
+            KnownChart::TimeSeries(b)
+            | KnownChart::Heatmap(b)
+            | KnownChart::LogStream(b)
+            | KnownChart::Pie(b)
+            | KnownChart::Scatter(b)
+            | KnownChart::Table(b)
+            | KnownChart::TopK(b)
+            | KnownChart::Statistic(b)
+            | KnownChart::Note(b) => b,
         }
     }
 
@@ -201,15 +276,15 @@ impl Chart {
     #[must_use]
     pub fn base_mut(&mut self) -> &mut ChartBase {
         match self {
-            Chart::TimeSeries(b)
-            | Chart::Heatmap(b)
-            | Chart::LogStream(b)
-            | Chart::Pie(b)
-            | Chart::Scatter(b)
-            | Chart::Table(b)
-            | Chart::TopK(b)
-            | Chart::Statistic(b)
-            | Chart::Note(b) => b,
+            KnownChart::TimeSeries(b)
+            | KnownChart::Heatmap(b)
+            | KnownChart::LogStream(b)
+            | KnownChart::Pie(b)
+            | KnownChart::Scatter(b)
+            | KnownChart::Table(b)
+            | KnownChart::TopK(b)
+            | KnownChart::Statistic(b)
+            | KnownChart::Note(b) => b,
         }
     }
 
@@ -217,15 +292,15 @@ impl Chart {
     #[must_use]
     pub fn type_str(&self) -> &'static str {
         match self {
-            Chart::TimeSeries(_) => "TimeSeries",
-            Chart::Heatmap(_) => "Heatmap",
-            Chart::LogStream(_) => "LogStream",
-            Chart::Pie(_) => "Pie",
-            Chart::Scatter(_) => "Scatter",
-            Chart::Table(_) => "Table",
-            Chart::TopK(_) => "TopK",
-            Chart::Statistic(_) => "Statistic",
-            Chart::Note(_) => "Note",
+            KnownChart::TimeSeries(_) => "TimeSeries",
+            KnownChart::Heatmap(_) => "Heatmap",
+            KnownChart::LogStream(_) => "LogStream",
+            KnownChart::Pie(_) => "Pie",
+            KnownChart::Scatter(_) => "Scatter",
+            KnownChart::Table(_) => "Table",
+            KnownChart::TopK(_) => "TopK",
+            KnownChart::Statistic(_) => "Statistic",
+            KnownChart::Note(_) => "Note",
         }
     }
 }
@@ -240,7 +315,7 @@ pub struct ChartBase {
     /// Stable per-dashboard chart identifier; matches [`LayoutItem::i`].
     pub id: String,
     /// Display name shown above the chart.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// Raw query specification for this chart.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/dashboards/model.rs
+++ b/src/dashboards/model.rs
@@ -1,0 +1,275 @@
+//! Types describing the dashboards `v2` API.
+//!
+//! The wire shape is intentionally permissive: every type carries an `extras`
+//! bucket capturing unknown fields, so an SDK build that pre-dates a server
+//! schema change can still round-trip a dashboard through `get` → `put`
+//! without silently dropping new fields.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// One dashboard resource as returned by the `v2` API.
+///
+/// `uid` is the path-friendly identifier used by [`Client::get`],
+/// [`Client::put`], and [`Client::delete`]. `version` is the
+/// server-assigned monotonic counter you must round-trip on writes unless
+/// you explicitly opt in to overwrite semantics.
+///
+/// [`Client::get`]: super::Client::get
+/// [`Client::put`]: super::Client::put
+/// [`Client::delete`]: super::Client::delete
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Dashboard {
+    /// Path-friendly dashboard identifier (used by the URI).
+    pub uid: String,
+    /// Numeric, internal identifier. Distinct from [`Dashboard::uid`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    /// When the dashboard was last persisted.
+    #[serde(rename = "updatedAt", default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<DateTime<Utc>>,
+    /// Who last persisted the dashboard.
+    #[serde(rename = "updatedBy", default, skip_serializing_if = "Option::is_none")]
+    pub updated_by: Option<String>,
+    /// Server-assigned monotonic version. Required as `version` on the
+    /// next `PUT` unless `overwrite=true` is sent; absent for hand-authored
+    /// payloads that have never been persisted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<i64>,
+    /// The nested document — charts, layout, time window, and everything
+    /// the server doesn't surface at the resource level.
+    #[serde(default)]
+    pub dashboard: DashboardDocument,
+}
+
+impl Dashboard {
+    /// Convenience accessor for `dashboard.name`.
+    #[must_use]
+    pub fn name(&self) -> Option<&str> {
+        self.dashboard.name.as_deref()
+    }
+
+    /// Convenience accessor for `dashboard.description`.
+    #[must_use]
+    pub fn description(&self) -> Option<&str> {
+        self.dashboard.description.as_deref()
+    }
+}
+
+/// Body of a dashboard create or update request.
+///
+/// Use [`Client::create`] or [`Client::put`] rather than building this
+/// directly; the helpers fill in `uid`, `version`, and `overwrite` so callers
+/// don't have to remember the version-check semantics.
+///
+/// [`Client::create`]: super::Client::create
+/// [`Client::put`]: super::Client::put
+#[derive(Debug, Clone, Serialize)]
+pub struct UpsertRequest<'a> {
+    /// The dashboard document being created or replaced.
+    pub dashboard: &'a DashboardDocument,
+    /// Expected current version on the server. Sent on update to opt into
+    /// the server's optimistic version check; omitted on create.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<i64>,
+    /// When `true`, the server skips the version check entirely.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub overwrite: bool,
+    /// Desired `uid`. Optional on create; the helper sets it for `PUT`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uid: Option<&'a str>,
+    /// Free-form description of the change, persisted as audit metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<&'a str>,
+}
+
+#[allow(clippy::trivially_copy_pass_by_ref)]
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+/// Response envelope shared by `POST /v2/dashboards` and
+/// `PUT /v2/dashboards/uid/{uid}`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct DashboardWriteResponse {
+    /// Whether the call created a new dashboard or updated an existing one.
+    pub status: DashboardWriteStatus,
+    /// `true` when the server skipped the version check.
+    #[serde(default)]
+    pub overwritten: Option<bool>,
+    /// Resulting resource, including the bumped `version`.
+    pub dashboard: Dashboard,
+}
+
+/// Distinguishes the two outcomes of a successful upsert.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DashboardWriteStatus {
+    /// A new dashboard was created.
+    Created,
+    /// An existing dashboard was updated.
+    Updated,
+}
+
+/// Nested dashboard document.
+///
+/// The server's spec is `additionalProperties: false` on this object, which
+/// means we have to round-trip exactly what came in or `PUT` will reject the
+/// payload. The [`DashboardDocument::extras`] bucket is the safety net for
+/// fields the SDK doesn't yet model.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct DashboardDocument {
+    /// Human-readable dashboard name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Optional one-line description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Charts on the dashboard. Order is preserved.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub charts: Vec<Chart>,
+    /// Grid placement for each chart. The server's coordinate system is
+    /// 12 columns wide; `y` may be `null` to auto-stack.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub layout: Vec<LayoutItem>,
+    /// Time window start (literal, e.g. `"now-1h"`).
+    #[serde(
+        rename = "timeWindowStart",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub time_window_start: Option<String>,
+    /// Time window end (literal, e.g. `"now"`).
+    #[serde(
+        rename = "timeWindowEnd",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub time_window_end: Option<String>,
+    /// Every other field the server returned. Preserved verbatim for
+    /// round-tripping. Includes (for example) `owner`, `refreshTime`,
+    /// `schemaVersion`, `against`, `againstTimestamp`, `uid`, …
+    #[serde(flatten)]
+    pub extras: serde_json::Map<String, serde_json::Value>,
+}
+
+/// One chart on a dashboard.
+///
+/// Each variant carries the shared [`ChartBase`] fields plus any
+/// chart-specific keys preserved verbatim in [`ChartBase::extras`].
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "type")]
+pub enum Chart {
+    /// Time-series line/area chart.
+    TimeSeries(ChartBase),
+    /// Heatmap chart.
+    Heatmap(ChartBase),
+    /// Log stream panel.
+    LogStream(ChartBase),
+    /// Pie chart.
+    Pie(ChartBase),
+    /// Scatter plot.
+    Scatter(ChartBase),
+    /// Tabular panel.
+    Table(ChartBase),
+    /// Top-K bar chart.
+    TopK(ChartBase),
+    /// Single-statistic panel.
+    Statistic(ChartBase),
+    /// Static markdown/HTML note panel.
+    Note(ChartBase),
+}
+
+impl Chart {
+    /// Borrow the shared chart fields regardless of variant.
+    #[must_use]
+    pub fn base(&self) -> &ChartBase {
+        match self {
+            Chart::TimeSeries(b)
+            | Chart::Heatmap(b)
+            | Chart::LogStream(b)
+            | Chart::Pie(b)
+            | Chart::Scatter(b)
+            | Chart::Table(b)
+            | Chart::TopK(b)
+            | Chart::Statistic(b)
+            | Chart::Note(b) => b,
+        }
+    }
+
+    /// Borrow the shared chart fields mutably regardless of variant.
+    #[must_use]
+    pub fn base_mut(&mut self) -> &mut ChartBase {
+        match self {
+            Chart::TimeSeries(b)
+            | Chart::Heatmap(b)
+            | Chart::LogStream(b)
+            | Chart::Pie(b)
+            | Chart::Scatter(b)
+            | Chart::Table(b)
+            | Chart::TopK(b)
+            | Chart::Statistic(b)
+            | Chart::Note(b) => b,
+        }
+    }
+
+    /// Human-readable type name, exactly as it appears on the wire.
+    #[must_use]
+    pub fn type_str(&self) -> &'static str {
+        match self {
+            Chart::TimeSeries(_) => "TimeSeries",
+            Chart::Heatmap(_) => "Heatmap",
+            Chart::LogStream(_) => "LogStream",
+            Chart::Pie(_) => "Pie",
+            Chart::Scatter(_) => "Scatter",
+            Chart::Table(_) => "Table",
+            Chart::TopK(_) => "TopK",
+            Chart::Statistic(_) => "Statistic",
+            Chart::Note(_) => "Note",
+        }
+    }
+}
+
+/// Fields shared by every chart variant.
+///
+/// The `query` shape differs per variant (e.g. `TimeSeriesChartQuery` vs
+/// `SimpleChartQuery`), so it is parked as raw JSON for the SDK consumer
+/// to interpret.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChartBase {
+    /// Stable per-dashboard chart identifier; matches [`LayoutItem::i`].
+    pub id: String,
+    /// Display name shown above the chart.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Raw query specification for this chart.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub query: Option<serde_json::Value>,
+    /// Any other fields the server returned for this chart variant
+    /// (e.g. `tableSettings`, `colorScheme`). Preserved verbatim for
+    /// round-trip.
+    #[serde(flatten)]
+    pub extras: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Grid placement for a chart, keyed by the chart's id.
+///
+/// The grid is 12 columns wide (`x` ∈ `0..=11`); `y` may be `None` to let the
+/// server auto-stack from the top.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LayoutItem {
+    /// Matches [`ChartBase::id`].
+    pub i: String,
+    /// Leftmost column occupied by the tile, in the range `0..=11`.
+    pub x: u32,
+    /// Topmost row occupied by the tile. `None` lets the server auto-stack.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub y: Option<u32>,
+    /// Tile width in columns.
+    pub w: u32,
+    /// Tile height in rows.
+    pub h: u32,
+    /// Any other fields preserved verbatim for round-trip.
+    #[serde(flatten)]
+    pub extras: serde_json::Map<String, serde_json::Value>,
+}

--- a/src/dashboards/tests.rs
+++ b/src/dashboards/tests.rs
@@ -1,12 +1,70 @@
-#![cfg(test)]
-
 use crate::{
-    dashboards::model::{DashboardDocument, DashboardWriteStatus},
+    dashboards::model::{Chart, DashboardDocument, DashboardWriteStatus, KnownChart, UpsertOptions},
     error::Error,
-    Client,
+    limits, Client,
 };
+use chrono::{Duration, Utc};
 use httpmock::prelude::*;
 use serde_json::json;
+
+#[test]
+fn chart_unknown_variant_round_trips() {
+    // A chart whose `type` the SDK doesn't model must deserialise into
+    // `Chart::Unknown(_)` and round-trip back to the original JSON without
+    // dropping any fields.
+    let raw = json!({
+        "type": "FutureChartKind",
+        "id": "c-1",
+        "name": "From the future",
+        "futureSetting": { "answer": 42 }
+    });
+    let chart: Chart = serde_json::from_value(raw.clone()).expect("chart decode");
+    match &chart {
+        Chart::Unknown(v) => assert_eq!(v.get("type").and_then(|t| t.as_str()), Some("FutureChartKind")),
+        Chart::Known(k) => panic!("expected Unknown, got Known: {:?}", k),
+    }
+    assert_eq!(chart.type_str(), Some("FutureChartKind"));
+    assert!(chart.base().is_none());
+    let round_tripped = serde_json::to_value(&chart).expect("chart encode");
+    assert_eq!(round_tripped, raw);
+}
+
+#[test]
+fn chart_known_variant_round_trips() {
+    let raw = json!({
+        "type": "TimeSeries",
+        "id": "c-2",
+        "name": "Latency",
+        "query": { "apl": "..." }
+    });
+    let chart: Chart = serde_json::from_value(raw.clone()).expect("chart decode");
+    match &chart {
+        Chart::Known(KnownChart::TimeSeries(base)) => assert_eq!(base.id, "c-2"),
+        other => panic!("expected Known::TimeSeries, got {:?}", other),
+    }
+    assert_eq!(chart.type_str(), Some("TimeSeries"));
+    let round_tripped = serde_json::to_value(&chart).expect("chart encode");
+    assert_eq!(round_tripped, raw);
+}
+
+#[test]
+fn chart_without_name_does_not_emit_null() {
+    // Regression: `ChartBase.name` used to round-trip absent fields as
+    // `"name": null`, which violates the dashboard document's
+    // `additionalProperties: false` constraint on some shapes.
+    let raw = json!({
+        "type": "TimeSeries",
+        "id": "c-3"
+    });
+    let chart: Chart = serde_json::from_value(raw.clone()).expect("chart decode");
+    let round_tripped = serde_json::to_value(&chart).expect("chart encode");
+    assert_eq!(round_tripped, raw);
+    assert!(
+        round_tripped.get("name").is_none(),
+        "absent name must not serialise as null, got {}",
+        round_tripped
+    );
+}
 
 #[tokio::test]
 async fn list_dashboards() -> Result<(), Box<dyn std::error::Error>> {
@@ -33,7 +91,7 @@ async fn list_dashboards() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(dashboards.len(), 1);
     assert_eq!(dashboards[0].uid, "dash-1");
     assert_eq!(dashboards[0].name(), Some("Latency"));
-    mock.assert();
+    mock.assert_hits_async(1).await;
     Ok(())
 }
 
@@ -56,7 +114,7 @@ async fn get_dashboard() -> Result<(), Box<dyn std::error::Error>> {
 
     let dashboard = client.dashboards().get("dash-1").await?;
     assert_eq!(dashboard.version, Some(5));
-    mock.assert();
+    mock.assert_hits_async(1).await;
     Ok(())
 }
 
@@ -80,12 +138,45 @@ async fn create_dashboard() -> Result<(), Box<dyn std::error::Error>> {
         .with_token("xaat-nope")
         .build()?;
 
-    let mut doc = DashboardDocument::default();
-    doc.name = Some("New".into());
-    let res = client.dashboards().create(&doc, None, None).await?;
+    let doc = DashboardDocument {
+        name: Some("New".into()),
+        ..Default::default()
+    };
+    let res = client.dashboards().create(&doc, None).await?;
     assert_eq!(res.status, DashboardWriteStatus::Created);
     assert_eq!(res.dashboard.uid, "dash-2");
-    mock.assert();
+    mock.assert_hits_async(1).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn put_dashboard_with_default_options() -> Result<(), Box<dyn std::error::Error>> {
+    // `put(uid, &doc, None)` must work: the `Into<Option<UpsertOptions>>`
+    // shortcut should produce the same wire shape as
+    // `UpsertOptions::default()`.
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(PUT).path("/v2/dashboards/uid/dash-1");
+        then.status(200).json_body(json!({
+            "status": "updated",
+            "dashboard": {
+                "uid": "dash-1",
+                "version": 4,
+                "dashboard": { "name": "x" }
+            }
+        }));
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    let doc = DashboardDocument::default();
+    let res = client.dashboards().put("dash-1", &doc, None).await?;
+    assert_eq!(res.status, DashboardWriteStatus::Updated);
+    assert_eq!(res.dashboard.version, Some(4));
+    mock.assert_hits_async(1).await;
     Ok(())
 }
 
@@ -110,9 +201,16 @@ async fn put_dashboard_version_conflict() -> Result<(), Box<dyn std::error::Erro
     let doc = DashboardDocument::default();
     let err = client
         .dashboards()
-        .put("dash-1", &doc, Some(3), false, None)
+        .put(
+            "dash-1",
+            &doc,
+            UpsertOptions {
+                expected_version: Some(3),
+                ..Default::default()
+            },
+        )
         .await
-        .unwrap_err();
+        .expect_err("expected DashboardVersionConflict");
     match err {
         Error::DashboardVersionConflict { uid, current } => {
             assert_eq!(uid, "dash-1");
@@ -120,7 +218,100 @@ async fn put_dashboard_version_conflict() -> Result<(), Box<dyn std::error::Erro
         }
         other => panic!("expected DashboardVersionConflict, got {:?}", other),
     }
-    mock.assert();
+    mock.assert_hits_async(1).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn put_dashboard_rate_limited() -> Result<(), Box<dyn std::error::Error>> {
+    // Regression test for the C2 refactor: dashboard writes used to
+    // bypass `check_error`, silently dropping limit-mapping. Now that
+    // we go through the shared path, a 429 with rate-limit headers must
+    // surface as `Error::RateLimitExceeded`.
+    let server = MockServer::start();
+    let reset = Utc::now() + Duration::seconds(60);
+    let mock = server.mock(|when, then| {
+        when.method(PUT).path("/v2/dashboards/uid/dash-1");
+        then.status(429)
+            .json_body(json!({ "message": "rate limit exceeded" }))
+            .header(limits::HEADER_RATE_SCOPE, "user")
+            .header(limits::HEADER_RATE_LIMIT, "42")
+            .header(limits::HEADER_RATE_REMAINING, "0")
+            .header(limits::HEADER_RATE_RESET, format!("{}", reset.timestamp()));
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    let doc = DashboardDocument::default();
+    let err = client
+        .dashboards()
+        .put(
+            "dash-1",
+            &doc,
+            UpsertOptions {
+                expected_version: Some(3),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("expected rate limit error");
+    match err {
+        Error::RateLimitExceeded { scope, limits } => {
+            assert_eq!(scope, "user");
+            assert_eq!(limits.limit, 42);
+            assert_eq!(limits.remaining, 0);
+        }
+        other => panic!("expected RateLimitExceeded, got {:?}", other),
+    }
+    mock.assert_hits_async(1).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn put_dashboard_412_without_current_version_falls_back_to_axiom() -> Result<(), Box<dyn std::error::Error>> {
+    // A 412 without `currentVersion` shouldn't panic on decode; we fall
+    // back to the generic `Error::Axiom` envelope.
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(PUT).path("/v2/dashboards/uid/dash-1");
+        then.status(412)
+            .json_body(json!({ "message": "precondition failed" }));
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    let doc = DashboardDocument::default();
+    let err = client
+        .dashboards()
+        .put(
+            "dash-1",
+            &doc,
+            UpsertOptions {
+                expected_version: Some(3),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect_err("expected generic Axiom error");
+    match err {
+        Error::Axiom(axiom) => {
+            assert_eq!(axiom.status, 412);
+            assert_eq!(axiom.message.as_deref(), Some("precondition failed"));
+            // The fallback must preserve method/path context so the error
+            // is debuggable, not the synthetic `“unknown PUT ”` we had
+            // before threading `Response::method`/`path` through.
+            assert_eq!(axiom.method, ::http::Method::PUT);
+            assert_eq!(axiom.path, "/v2/dashboards/uid/dash-1");
+        }
+        other => panic!("expected Error::Axiom, got {:?}", other),
+    }
+    mock.assert_hits_async(1).await;
     Ok(())
 }
 
@@ -138,6 +329,6 @@ async fn delete_dashboard() -> Result<(), Box<dyn std::error::Error>> {
         .build()?;
 
     client.dashboards().delete("dash-1").await?;
-    mock.assert();
+    mock.assert_hits_async(1).await;
     Ok(())
 }

--- a/src/dashboards/tests.rs
+++ b/src/dashboards/tests.rs
@@ -1,5 +1,7 @@
 use crate::{
-    dashboards::model::{Chart, DashboardDocument, DashboardWriteStatus, KnownChart, UpsertOptions},
+    dashboards::model::{
+        Chart, DashboardDocument, DashboardWriteStatus, KnownChart, UpsertOptions,
+    },
     error::Error,
     limits, Client,
 };
@@ -20,7 +22,10 @@ fn chart_unknown_variant_round_trips() {
     });
     let chart: Chart = serde_json::from_value(raw.clone()).expect("chart decode");
     match &chart {
-        Chart::Unknown(v) => assert_eq!(v.get("type").and_then(|t| t.as_str()), Some("FutureChartKind")),
+        Chart::Unknown(v) => assert_eq!(
+            v.get("type").and_then(|t| t.as_str()),
+            Some("FutureChartKind")
+        ),
         Chart::Known(k) => panic!("expected Unknown, got Known: {:?}", k),
     }
     assert_eq!(chart.type_str(), Some("FutureChartKind"));
@@ -271,7 +276,8 @@ async fn put_dashboard_rate_limited() -> Result<(), Box<dyn std::error::Error>> 
 }
 
 #[tokio::test]
-async fn put_dashboard_412_without_current_version_falls_back_to_axiom() -> Result<(), Box<dyn std::error::Error>> {
+async fn put_dashboard_412_without_current_version_falls_back_to_axiom(
+) -> Result<(), Box<dyn std::error::Error>> {
     // A 412 without `currentVersion` shouldn't panic on decode; we fall
     // back to the generic `Error::Axiom` envelope.
     let server = MockServer::start();

--- a/src/dashboards/tests.rs
+++ b/src/dashboards/tests.rs
@@ -1,0 +1,143 @@
+#![cfg(test)]
+
+use crate::{
+    dashboards::model::{DashboardDocument, DashboardWriteStatus},
+    error::Error,
+    Client,
+};
+use httpmock::prelude::*;
+use serde_json::json;
+
+#[tokio::test]
+async fn list_dashboards() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/v2/dashboards")
+            .query_param("limit", "1000");
+        then.status(200).json_body(json!([
+            {
+                "uid": "dash-1",
+                "version": 3,
+                "dashboard": { "name": "Latency", "charts": [], "layout": [] }
+            }
+        ]));
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    let dashboards = client.dashboards().list().await?;
+    assert_eq!(dashboards.len(), 1);
+    assert_eq!(dashboards[0].uid, "dash-1");
+    assert_eq!(dashboards[0].name(), Some("Latency"));
+    mock.assert();
+    Ok(())
+}
+
+#[tokio::test]
+async fn get_dashboard() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(GET).path("/v2/dashboards/uid/dash-1");
+        then.status(200).json_body(json!({
+            "uid": "dash-1",
+            "version": 5,
+            "dashboard": { "name": "Errors" }
+        }));
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    let dashboard = client.dashboards().get("dash-1").await?;
+    assert_eq!(dashboard.version, Some(5));
+    mock.assert();
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_dashboard() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/v2/dashboards");
+        then.status(200).json_body(json!({
+            "status": "created",
+            "dashboard": {
+                "uid": "dash-2",
+                "version": 1,
+                "dashboard": { "name": "New" }
+            }
+        }));
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    let mut doc = DashboardDocument::default();
+    doc.name = Some("New".into());
+    let res = client.dashboards().create(&doc, None, None).await?;
+    assert_eq!(res.status, DashboardWriteStatus::Created);
+    assert_eq!(res.dashboard.uid, "dash-2");
+    mock.assert();
+    Ok(())
+}
+
+#[tokio::test]
+async fn put_dashboard_version_conflict() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(PUT).path("/v2/dashboards/uid/dash-1");
+        then.status(412).json_body(json!({
+            "code": "version_mismatch",
+            "message": "stale version",
+            "currentVersion": 7,
+            "uid": "dash-1"
+        }));
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    let doc = DashboardDocument::default();
+    let err = client
+        .dashboards()
+        .put("dash-1", &doc, Some(3), false, None)
+        .await
+        .unwrap_err();
+    match err {
+        Error::DashboardVersionConflict { uid, current } => {
+            assert_eq!(uid, "dash-1");
+            assert_eq!(current, 7);
+        }
+        other => panic!("expected DashboardVersionConflict, got {:?}", other),
+    }
+    mock.assert();
+    Ok(())
+}
+
+#[tokio::test]
+async fn delete_dashboard() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(DELETE).path("/v2/dashboards/uid/dash-1");
+        then.status(204);
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    client.dashboards().delete("dash-1").await?;
+    mock.assert();
+    Ok(())
+}

--- a/src/datasets/model.rs
+++ b/src/datasets/model.rs
@@ -135,7 +135,18 @@ pub struct Dataset {
     /// The time the dataset was created at.
     #[serde(rename = "created")]
     pub created_at: DateTime<Utc>,
-    // ignored: integrationConfigs, integrationFilters, quickQueries
+    /// Dataset kind, e.g. `"otel:metrics:v1"`. `None` for legacy/event
+    /// datasets that pre-date the field, or when the server doesn't emit
+    /// it.
+    #[serde(default)]
+    pub kind: Option<String>,
+    /// Regional edge deployment for this dataset, e.g.
+    /// `"eu-central-1.aws.edge.axiom.co"`. `None` when the dataset isn't
+    /// pinned to an edge.
+    #[serde(rename = "edgeDeployment", default)]
+    pub edge_deployment: Option<String>,
+    // ignored: id, canWrite, useRetentionPeriod, retentionDays, mapFields,
+    // integrationConfigs, integrationFilters, quickQueries
 }
 
 /// Details of the information stored in a dataset.
@@ -696,6 +707,38 @@ pub struct EntryGroupAgg {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn dataset_decodes_kind_and_edge_deployment() {
+        let json = r#"{
+            "name": "metrics-eu",
+            "description": "",
+            "who": "u1",
+            "created": "2024-01-01T00:00:00Z",
+            "kind": "otel:metrics:v1",
+            "edgeDeployment": "eu-central-1.aws.edge.axiom.co"
+        }"#;
+        let dataset: Dataset = serde_json::from_str(json).expect("valid dataset json");
+        assert_eq!(dataset.kind.as_deref(), Some("otel:metrics:v1"));
+        assert_eq!(
+            dataset.edge_deployment.as_deref(),
+            Some("eu-central-1.aws.edge.axiom.co")
+        );
+    }
+
+    #[test]
+    fn dataset_decodes_without_new_fields() {
+        // Backwards-compat: missing fields must decode as `None`.
+        let json = r#"{
+            "name": "legacy",
+            "description": "",
+            "who": "u1",
+            "created": "2024-01-01T00:00:00Z"
+        }"#;
+        let dataset: Dataset = serde_json::from_str(json).expect("valid dataset json");
+        assert!(dataset.kind.is_none());
+        assert!(dataset.edge_deployment.is_none());
+    }
 
     #[test]
     fn test_aggregation_op() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -101,6 +101,19 @@ pub enum Error {
     )]
     /// Personal tokens are not supported for edge endpoints.
     PersonalTokenNotSupportedForEdge,
+    #[error(
+        "Dashboard version mismatch on uid {uid:?}: server is at version {current}. \
+         Reload the dashboard or retry with `overwrite = true`."
+    )]
+    /// The server's optimistic version check rejected a dashboard write.
+    /// Carries the server's current version so the caller can show a useful
+    /// diff or reload prompt.
+    DashboardVersionConflict {
+        /// `uid` of the dashboard the conflict was reported for.
+        uid: String,
+        /// Current version on the server.
+        current: i64,
+    },
 }
 
 /// This is the manual implementation. We don't really care if the error is

--- a/src/http.rs
+++ b/src/http.rs
@@ -209,8 +209,22 @@ impl Client {
         S: AsRef<str>,
     {
         self.execute(http::Method::DELETE, path, Body::Empty, None)
+            .await?
+            .check_error()
             .await?;
         Ok(())
+    }
+
+    /// `OPTIONS` with an explicit set of additional request headers
+    /// (typically a custom `Accept`). Used by self-describing endpoints
+    /// such as the MPL spec at `OPTIONS /v1/query/_mpl`.
+    pub(crate) async fn options_with_headers<S, H>(&self, path: S, headers: H) -> Result<Response>
+    where
+        S: AsRef<str>,
+        H: Into<Option<HeaderMap>>,
+    {
+        self.execute(http::Method::OPTIONS, path.as_ref(), Body::Empty, headers)
+            .await
     }
 }
 
@@ -240,6 +254,44 @@ impl Response {
             .json::<T>()
             .await
             .map_err(Error::Deserialize)
+    }
+
+    /// Cheap status peek without consuming the response.
+    pub(crate) fn status(&self) -> http::StatusCode {
+        self.inner.status()
+    }
+
+    /// HTTP method this response was produced from.
+    pub(crate) fn method(&self) -> &http::Method {
+        &self.method
+    }
+
+    /// Path this response was produced from.
+    pub(crate) fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// Read the response body as text, after running [`check_error`].
+    /// Use this for happy-path text consumers (e.g. the MPL spec at
+    /// `OPTIONS /v1/query/_mpl` returning markdown).
+    ///
+    /// [`check_error`]: Self::check_error
+    pub(crate) async fn text(self) -> Result<String> {
+        self.check_error()
+            .await?
+            .inner
+            .text()
+            .await
+            .map_err(Error::Http)
+    }
+
+    /// Read the raw response body as text **without** running
+    /// [`check_error`]. Used by callers that need to decode a typed error
+    /// envelope from a non-2xx body (e.g. dashboards' 412 conflict path).
+    ///
+    /// [`check_error`]: Self::check_error
+    pub(crate) async fn body_text_unchecked(self) -> Result<String> {
+        self.inner.text().await.map_err(Error::Http)
     }
 
     pub(crate) async fn check_error(self) -> Result<Response> {
@@ -308,6 +360,35 @@ mod test {
     use serde_json::json;
 
     use crate::{limits, Client, Error};
+
+    #[tokio::test]
+    async fn test_delete_surfaces_non_2xx_errors() -> Result<(), Box<dyn std::error::Error>> {
+        // Regression test for the C2 fix: `http::Client::delete` used to
+        // drop the response without checking the status, silently treating
+        // any HTTP error as success. It must now surface non-2xx as
+        // `Error::Axiom`.
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(DELETE).path("/v1/datasets/missing");
+            then.status(404)
+                .json_body(json!({ "message": "dataset not found" }));
+        });
+        let client = Client::builder()
+            .no_env()
+            .with_url(server.base_url())
+            .with_token("xapt-nope")
+            .build()?;
+
+        match client.datasets().delete("missing").await {
+            Err(Error::Axiom(axiom)) => {
+                assert_eq!(axiom.status, 404);
+                assert_eq!(axiom.message.as_deref(), Some("dataset not found"));
+            }
+            other => panic!("expected Error::Axiom on DELETE 404, got {:?}", other),
+        }
+        mock.assert_hits_async(1).await;
+        Ok(())
+    }
 
     #[tokio::test]
     async fn test_ingest_limit_exceeded() -> Result<(), Box<dyn std::error::Error>> {
@@ -471,7 +552,7 @@ mod test {
             .with_token("xaat-test")
             .with_edge("eu-central-1.aws.edge.axiom.co")
             .build()
-            .unwrap();
+            .expect("test client build");
 
         assert!(client.uses_edge());
         assert_eq!(client.edge_url(), "https://eu-central-1.aws.edge.axiom.co");
@@ -589,7 +670,7 @@ mod test {
             .with_token("xaat-test")
             .with_edge("eu-central-1.aws.edge.axiom.co")
             .build()
-            .unwrap();
+            .expect("test client build");
 
         assert_eq!(client.edge_url(), "https://eu-central-1.aws.edge.axiom.co");
         assert!(client.uses_edge());
@@ -603,7 +684,7 @@ mod test {
             .with_edge("eu-central-1.aws.edge.axiom.co")
             .with_edge_url("https://custom.ingest.endpoint")
             .build()
-            .unwrap();
+            .expect("test client build");
 
         assert_eq!(client.edge_url(), "https://custom.ingest.endpoint");
     }
@@ -615,7 +696,7 @@ mod test {
             .no_env()
             .with_token("xaat-test")
             .build()
-            .unwrap();
+            .expect("test client build");
 
         assert_eq!(client.api_url(), "https://api.axiom.co");
         assert_eq!(client.edge_url(), "https://api.axiom.co");
@@ -630,7 +711,7 @@ mod test {
             .with_token("xaat-test")
             .with_url("https://my-axiom-instance.example.com")
             .build()
-            .unwrap();
+            .expect("test client build");
 
         assert_eq!(client.api_url(), "https://my-axiom-instance.example.com");
         assert_eq!(client.edge_url(), "https://my-axiom-instance.example.com");
@@ -648,7 +729,7 @@ mod test {
             .with_token("xapt-personal-token")
             .with_edge("eu-central-1.aws.edge.axiom.co")
             .build()
-            .unwrap();
+            .expect("test client build");
 
         let result = client
             .ingest("test-dataset", vec![serde_json::json!({"foo": "bar"})])

--- a/src/http.rs
+++ b/src/http.rs
@@ -121,6 +121,18 @@ impl Client {
             .await
     }
 
+    /// `GET` with an explicit set of additional request headers (typically a
+    /// custom `Accept`). Existing default headers from the client are
+    /// preserved.
+    pub(crate) async fn get_with_headers<S, H>(&self, path: S, headers: H) -> Result<Response>
+    where
+        S: AsRef<str>,
+        H: Into<Option<HeaderMap>>,
+    {
+        self.execute(http::Method::GET, path.as_ref(), Body::Empty, headers)
+            .await
+    }
+
     pub(crate) async fn post<S, P>(&self, path: S, payload: P) -> Result<Response>
     where
         S: AsRef<str>,
@@ -131,6 +143,29 @@ impl Client {
             path,
             Body::Json(serde_json::to_value(payload).map_err(Error::Serialize)?),
             None,
+        )
+        .await
+    }
+
+    /// `POST` JSON payload with an explicit set of additional request headers
+    /// (typically a custom `Accept`). Existing default headers from the client
+    /// are preserved.
+    pub(crate) async fn post_with_headers<S, P, H>(
+        &self,
+        path: S,
+        payload: P,
+        headers: H,
+    ) -> Result<Response>
+    where
+        S: AsRef<str>,
+        P: Serialize,
+        H: Into<Option<HeaderMap>>,
+    {
+        self.execute(
+            http::Method::POST,
+            path,
+            Body::Json(serde_json::to_value(payload).map_err(Error::Serialize)?),
+            headers,
         )
         .await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,9 @@ pub mod limits;
 mod serde;
 
 pub mod annotations;
+pub mod dashboards;
 pub mod datasets;
+pub mod metrics;
 pub mod users;
 
 pub use client::{Client, RequestOptions};

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -34,6 +34,7 @@
 //! ```
 mod client;
 mod model;
+#[cfg(test)]
 mod tests;
 
 pub use client::{Client, MplQueryOptions};

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,40 @@
+//! Discover metrics, browse their tags, and run MPL queries against the
+//! Axiom edge endpoint.
+//!
+//! You're probably looking for the [`Client`].
+//!
+//! # Examples
+//! ```no_run
+//! use axiom_rs::{Client, Error};
+//! use chrono::{Duration, Utc};
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Error> {
+//!     let client = Client::new()?;
+//!     let end = Utc::now();
+//!     let start = end - Duration::hours(1);
+//!
+//!     // What metrics live in this dataset over the last hour?
+//!     let info = client.metrics().list("my-metrics-dataset", start, end).await?;
+//!     for (name, meta) in &info {
+//!         println!("{name}\t{:?}\t{:?}", meta.kind, meta.unit);
+//!     }
+//!
+//!     // Run an MPL query.
+//!     let res = client
+//!         .metrics()
+//!         .query("metric('http_requests_total') | rate(1m)", start, end, None)
+//!         .await?;
+//!     for series in &res.series {
+//!         println!("{}\t{} points", series.metric, series.data.len());
+//!     }
+//!
+//!     Ok(())
+//! }
+//! ```
+mod client;
+mod model;
+mod tests;
+
+pub use client::{Client, MplQueryOptions};
+pub use model::{MetricInfo, MetricsQueryResponse, MetricsSeries};

--- a/src/metrics/client.rs
+++ b/src/metrics/client.rs
@@ -93,9 +93,7 @@ impl<'client> Client<'client> {
         let dataset = dataset.into();
         let metric = encode_segment(&metric.into());
         let qs = TimeRange::new(start, end).to_query()?;
-        let path = format!(
-            "/v1/query/metrics/info/datasets/{dataset}/metrics/{metric}/tags?{qs}"
-        );
+        let path = format!("/v1/query/metrics/info/datasets/{dataset}/metrics/{metric}/tags?{qs}");
         self.http_client.get(path).await?.json().await
     }
 

--- a/src/metrics/client.rs
+++ b/src/metrics/client.rs
@@ -8,15 +8,37 @@ use serde::Serialize;
 use tracing::instrument;
 
 use crate::{
-    error::Result,
+    error::{Error, Result},
     http,
     metrics::model::{MetricInfo, MetricsQueryResponse},
 };
+
+/// `?start=...&end=...` query string used by every metrics-info endpoint.
+/// Serialised through `serde_qs` so we get consistent encoding without
+/// hand-rolling a percent-encoder for the timestamps.
+#[derive(Serialize)]
+struct TimeRange {
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+}
+
+impl TimeRange {
+    fn new(start: DateTime<Utc>, end: DateTime<Utc>) -> Self {
+        Self { start, end }
+    }
+
+    /// Render as `start=...&end=...` (no leading `?`).
+    fn to_query(&self) -> Result<String> {
+        serde_qs::to_string(self).map_err(Error::from)
+    }
+}
 
 /// Accept header for the metrics-info endpoint.
 const ACCEPT_METRICS_INFO_V2: &str = "application/vnd.metrics-info.v2+json";
 /// Accept header for the `_mpl` query endpoint.
 const ACCEPT_METRICS_V2: &str = "application/json+metrics.v2";
+/// Accept header for the self-describing MPL spec.
+const ACCEPT_MARKDOWN: &str = "text/markdown";
 
 /// Provides methods to work with Axiom metrics: metric discovery, tag
 /// listing, and MPL queries against the edge endpoint.
@@ -38,22 +60,15 @@ impl<'client> Client<'client> {
     /// Returns an error if the HTTP request fails or the response cannot be
     /// deserialised.
     #[instrument(skip(self))]
-    pub async fn list<D>(
+    pub async fn list(
         &self,
-        dataset: D,
+        dataset: impl Into<String> + FmtDebug,
         start: DateTime<Utc>,
         end: DateTime<Utc>,
-    ) -> Result<BTreeMap<String, MetricInfo>>
-    where
-        D: Into<String> + FmtDebug,
-    {
+    ) -> Result<BTreeMap<String, MetricInfo>> {
         let dataset = dataset.into();
-        let path = format!(
-            "/v1/query/metrics/info/datasets/{}/metrics?start={}&end={}",
-            dataset,
-            encode_rfc3339(start),
-            encode_rfc3339(end),
-        );
+        let qs = TimeRange::new(start, end).to_query()?;
+        let path = format!("/v1/query/metrics/info/datasets/{dataset}/metrics?{qs}");
         self.http_client
             .get_with_headers(path, accept_header(ACCEPT_METRICS_INFO_V2))
             .await?
@@ -68,25 +83,18 @@ impl<'client> Client<'client> {
     /// Returns an error if the HTTP request fails or the response cannot be
     /// deserialised.
     #[instrument(skip(self))]
-    pub async fn tags<D, M>(
+    pub async fn tags(
         &self,
-        dataset: D,
-        metric: M,
+        dataset: impl Into<String> + FmtDebug,
+        metric: impl Into<String> + FmtDebug,
         start: DateTime<Utc>,
         end: DateTime<Utc>,
-    ) -> Result<Vec<String>>
-    where
-        D: Into<String> + FmtDebug,
-        M: Into<String> + FmtDebug,
-    {
+    ) -> Result<Vec<String>> {
         let dataset = dataset.into();
-        let metric = metric.into();
+        let metric = encode_segment(&metric.into());
+        let qs = TimeRange::new(start, end).to_query()?;
         let path = format!(
-            "/v1/query/metrics/info/datasets/{}/metrics/{}/tags?start={}&end={}",
-            dataset,
-            url_segment(&metric),
-            encode_rfc3339(start),
-            encode_rfc3339(end),
+            "/v1/query/metrics/info/datasets/{dataset}/metrics/{metric}/tags?{qs}"
         );
         self.http_client.get(path).await?.json().await
     }
@@ -98,31 +106,109 @@ impl<'client> Client<'client> {
     /// Returns an error if the HTTP request fails or the response cannot be
     /// deserialised.
     #[instrument(skip(self))]
-    pub async fn tag_values<D, M, T>(
+    pub async fn tag_values(
         &self,
-        dataset: D,
-        metric: M,
-        tag: T,
+        dataset: impl Into<String> + FmtDebug,
+        metric: impl Into<String> + FmtDebug,
+        tag: impl Into<String> + FmtDebug,
         start: DateTime<Utc>,
         end: DateTime<Utc>,
-    ) -> Result<Vec<String>>
-    where
-        D: Into<String> + FmtDebug,
-        M: Into<String> + FmtDebug,
-        T: Into<String> + FmtDebug,
-    {
+    ) -> Result<Vec<String>> {
         let dataset = dataset.into();
-        let metric = metric.into();
-        let tag = tag.into();
+        let metric = encode_segment(&metric.into());
+        let tag = encode_segment(&tag.into());
+        let qs = TimeRange::new(start, end).to_query()?;
         let path = format!(
-            "/v1/query/metrics/info/datasets/{}/metrics/{}/tags/{}/values?start={}&end={}",
-            dataset,
-            url_segment(&metric),
-            url_segment(&tag),
-            encode_rfc3339(start),
-            encode_rfc3339(end),
+            "/v1/query/metrics/info/datasets/{dataset}/metrics/{metric}/tags/{tag}/values?{qs}"
         );
         self.http_client.get(path).await?.json().await
+    }
+
+    /// List the tag names observed across **all metrics** of `dataset`
+    /// between `start` and `end`.
+    ///
+    /// The per-metric pair lives on [`Client::tags`] / [`Client::tag_values`];
+    /// this dataset-level variant is the right starting point when you
+    /// don't yet know which metrics carry the tag you care about.
+    ///
+    /// # Errors
+    /// Returns an error if the HTTP request fails or the response cannot be
+    /// deserialised.
+    #[instrument(skip(self))]
+    pub async fn dataset_tags(
+        &self,
+        dataset: impl Into<String> + FmtDebug,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Result<Vec<String>> {
+        let dataset = dataset.into();
+        let qs = TimeRange::new(start, end).to_query()?;
+        let path = format!("/v1/query/metrics/info/datasets/{dataset}/tags?{qs}");
+        self.http_client.get(path).await?.json().await
+    }
+
+    /// List the observed values for a dataset-level `tag` across all
+    /// metrics of `dataset` between `start` and `end`.
+    ///
+    /// # Errors
+    /// Returns an error if the HTTP request fails or the response cannot be
+    /// deserialised.
+    #[instrument(skip(self))]
+    pub async fn dataset_tag_values(
+        &self,
+        dataset: impl Into<String> + FmtDebug,
+        tag: impl Into<String> + FmtDebug,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Result<Vec<String>> {
+        let dataset = dataset.into();
+        let tag = encode_segment(&tag.into());
+        let qs = TimeRange::new(start, end).to_query()?;
+        let path = format!("/v1/query/metrics/info/datasets/{dataset}/tags/{tag}/values?{qs}");
+        self.http_client.get(path).await?.json().await
+    }
+
+    /// Find metrics in `dataset` that carry `value` on any tag, between
+    /// `start` and `end`. Searches tag **values**, not metric names — use
+    /// this when you know a specific entity (service, host, device) and
+    /// want to find which metrics report it.
+    ///
+    /// # Errors
+    /// Returns an error if the HTTP request fails or the response cannot be
+    /// deserialised.
+    #[instrument(skip(self))]
+    pub async fn find_metrics(
+        &self,
+        dataset: impl Into<String> + FmtDebug,
+        value: impl Into<String> + FmtDebug,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Result<Vec<String>> {
+        let dataset = dataset.into();
+        let qs = TimeRange::new(start, end).to_query()?;
+        let path = format!("/v1/query/metrics/info/datasets/{dataset}/metrics?{qs}");
+        let body = FindMetricsRequest {
+            value: value.into(),
+        };
+        self.http_client.post(path, body).await?.json().await
+    }
+
+    /// Fetch the self-describing MPL spec as markdown.
+    ///
+    /// The MPL operator set evolves; this endpoint is the source of truth
+    /// for syntax, operator names, and parameter literal formats. Useful
+    /// for grounding LLM callers in the current surface.
+    ///
+    /// # Errors
+    /// Returns an error if the HTTP request fails or the server reports an
+    /// error.
+    #[instrument(skip(self))]
+    pub async fn spec(&self) -> Result<String> {
+        self.http_client
+            .options_with_headers("/v1/query/_mpl", accept_header(ACCEPT_MARKDOWN))
+            .await?
+            .text()
+            .await
     }
 
     /// Run an MPL query against the edge endpoint.
@@ -131,8 +217,8 @@ impl<'client> Client<'client> {
     /// is MPL, not APL.
     ///
     /// # Errors
-    /// Returns an error if the HTTP request fails or the response cannot be
-    /// deserialised.
+    /// Returns an error if the HTTP request fails, the response cannot be
+    /// deserialised, or a trace-id response header contains invalid bytes.
     #[instrument(skip(self, opts))]
     pub async fn query<S, O>(
         &self,
@@ -146,12 +232,20 @@ impl<'client> Client<'client> {
         O: Into<Option<MplQueryOptions>>,
     {
         let opts = opts.into().unwrap_or_default();
+        // The server expects parameter keys prefixed with `param__`.
+        // Callers pass plain variable names (e.g. `svc`); we apply the
+        // prefix here so the SDK surface mirrors the MPL `$svc` syntax.
+        let params = opts
+            .params
+            .into_iter()
+            .map(|(k, v)| (format!("param__{k}"), v))
+            .collect();
         let body = MplQueryRequest {
             apl: mpl.to_string(),
             start_time: start,
             end_time: end,
             query_edge_deployment: opts.edge_deployment,
-            query_params: opts.params,
+            params,
         };
 
         let resp = self
@@ -162,8 +256,9 @@ impl<'client> Client<'client> {
         let trace_id = resp
             .headers()
             .get("x-axiom-trace-id")
-            .or_else(|| resp.headers().get("traceparent"))
-            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_str())
+            .transpose()
+            .map_err(|_e| Error::InvalidTraceId)?
             .map(ToString::to_string);
 
         let mut result: MetricsQueryResponse = resp.json().await?;
@@ -174,14 +269,24 @@ impl<'client> Client<'client> {
 
 /// Per-call options for [`Client::query`].
 #[derive(Debug, Clone, Default)]
+#[must_use]
 pub struct MplQueryOptions {
     /// Override the edge deployment string sent as `queryEdgeDeployment`
     /// (e.g. `"cloud.eu-central-1.aws"`). When `None` the server picks
     /// a default for the configured edge URL.
     pub edge_deployment: Option<String>,
-    /// User-supplied MPL `param` values; serialised as `queryParams`. Use
-    /// an empty map to omit the field entirely.
+    /// MPL `param` values, keyed by the variable name (no leading `$`,
+    /// no `param__` prefix — the SDK adds it). Values are forwarded
+    /// verbatim as **MPL literals**, so string literals must include their
+    /// own quotes (e.g. `"\"frontend\""`, not `"frontend"`); see the MPL
+    /// spec for per-type literal syntax. An empty map omits the field
+    /// entirely.
     pub params: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Serialize)]
+struct FindMetricsRequest {
+    value: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -192,8 +297,10 @@ struct MplQueryRequest {
     end_time: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     query_edge_deployment: Option<String>,
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    query_params: BTreeMap<String, String>,
+    // Wire name is `params`, not `queryParams`. Keys must already carry
+    // the `param__` prefix (applied by `Client::query`).
+    #[serde(rename = "params", skip_serializing_if = "BTreeMap::is_empty")]
+    params: BTreeMap<String, String>,
 }
 
 /// Build an `Accept`-only header map.
@@ -206,14 +313,10 @@ fn accept_header(value: &'static str) -> HeaderMap {
     headers
 }
 
-/// Format a timestamp the way the metrics-info endpoint requires:
-/// strict RFC3339, percent-encoded so `:` and `+` round-trip safely.
-fn encode_rfc3339(t: DateTime<Utc>) -> String {
-    url_segment(&t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
-}
-
-/// Minimal percent-encoding for a URL path/query segment.
-fn url_segment(s: &str) -> String {
+/// Percent-encode a URL path segment using the RFC3986 unreserved set.
+/// Used for `metric` and `tag` identifiers that flow into the path; the
+/// `?start=...&end=...` query string is built via `serde_qs`.
+fn encode_segment(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for b in s.bytes() {
         match b {

--- a/src/metrics/client.rs
+++ b/src/metrics/client.rs
@@ -1,0 +1,230 @@
+use std::{collections::BTreeMap, fmt::Debug as FmtDebug};
+
+use std::fmt::Write;
+
+use ::http::header::{HeaderMap, HeaderValue, ACCEPT};
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use tracing::instrument;
+
+use crate::{
+    error::Result,
+    http,
+    metrics::model::{MetricInfo, MetricsQueryResponse},
+};
+
+/// Accept header for the metrics-info endpoint.
+const ACCEPT_METRICS_INFO_V2: &str = "application/vnd.metrics-info.v2+json";
+/// Accept header for the `_mpl` query endpoint.
+const ACCEPT_METRICS_V2: &str = "application/json+metrics.v2";
+
+/// Provides methods to work with Axiom metrics: metric discovery, tag
+/// listing, and MPL queries against the edge endpoint.
+///
+/// Obtain an instance via [`crate::Client::metrics`].
+#[derive(Debug, Clone)]
+pub struct Client<'client> {
+    http_client: &'client http::Client,
+}
+
+impl<'client> Client<'client> {
+    pub(crate) fn new(http_client: &'client http::Client) -> Self {
+        Self { http_client }
+    }
+
+    /// List the metrics observed in `dataset` between `start` and `end`.
+    ///
+    /// # Errors
+    /// Returns an error if the HTTP request fails or the response cannot be
+    /// deserialised.
+    #[instrument(skip(self))]
+    pub async fn list<D>(
+        &self,
+        dataset: D,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Result<BTreeMap<String, MetricInfo>>
+    where
+        D: Into<String> + FmtDebug,
+    {
+        let dataset = dataset.into();
+        let path = format!(
+            "/v1/query/metrics/info/datasets/{}/metrics?start={}&end={}",
+            dataset,
+            encode_rfc3339(start),
+            encode_rfc3339(end),
+        );
+        self.http_client
+            .get_with_headers(path, accept_header(ACCEPT_METRICS_INFO_V2))
+            .await?
+            .json()
+            .await
+    }
+
+    /// List the tag names observed for `(dataset, metric)` between `start`
+    /// and `end`.
+    ///
+    /// # Errors
+    /// Returns an error if the HTTP request fails or the response cannot be
+    /// deserialised.
+    #[instrument(skip(self))]
+    pub async fn tags<D, M>(
+        &self,
+        dataset: D,
+        metric: M,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Result<Vec<String>>
+    where
+        D: Into<String> + FmtDebug,
+        M: Into<String> + FmtDebug,
+    {
+        let dataset = dataset.into();
+        let metric = metric.into();
+        let path = format!(
+            "/v1/query/metrics/info/datasets/{}/metrics/{}/tags?start={}&end={}",
+            dataset,
+            url_segment(&metric),
+            encode_rfc3339(start),
+            encode_rfc3339(end),
+        );
+        self.http_client.get(path).await?.json().await
+    }
+
+    /// List the observed values for `tag` of `(dataset, metric)` between
+    /// `start` and `end`.
+    ///
+    /// # Errors
+    /// Returns an error if the HTTP request fails or the response cannot be
+    /// deserialised.
+    #[instrument(skip(self))]
+    pub async fn tag_values<D, M, T>(
+        &self,
+        dataset: D,
+        metric: M,
+        tag: T,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Result<Vec<String>>
+    where
+        D: Into<String> + FmtDebug,
+        M: Into<String> + FmtDebug,
+        T: Into<String> + FmtDebug,
+    {
+        let dataset = dataset.into();
+        let metric = metric.into();
+        let tag = tag.into();
+        let path = format!(
+            "/v1/query/metrics/info/datasets/{}/metrics/{}/tags/{}/values?start={}&end={}",
+            dataset,
+            url_segment(&metric),
+            url_segment(&tag),
+            encode_rfc3339(start),
+            encode_rfc3339(end),
+        );
+        self.http_client.get(path).await?.json().await
+    }
+
+    /// Run an MPL query against the edge endpoint.
+    ///
+    /// The request field name is `apl` for historical reasons; the payload
+    /// is MPL, not APL.
+    ///
+    /// # Errors
+    /// Returns an error if the HTTP request fails or the response cannot be
+    /// deserialised.
+    #[instrument(skip(self, opts))]
+    pub async fn query<S, O>(
+        &self,
+        mpl: &S,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        opts: O,
+    ) -> Result<MetricsQueryResponse>
+    where
+        S: ToString + FmtDebug + ?Sized,
+        O: Into<Option<MplQueryOptions>>,
+    {
+        let opts = opts.into().unwrap_or_default();
+        let body = MplQueryRequest {
+            apl: mpl.to_string(),
+            start_time: start,
+            end_time: end,
+            query_edge_deployment: opts.edge_deployment,
+            query_params: opts.params,
+        };
+
+        let resp = self
+            .http_client
+            .post_with_headers("/v1/query/_mpl", &body, accept_header(ACCEPT_METRICS_V2))
+            .await?;
+
+        let trace_id = resp
+            .headers()
+            .get("x-axiom-trace-id")
+            .or_else(|| resp.headers().get("traceparent"))
+            .and_then(|v| v.to_str().ok())
+            .map(ToString::to_string);
+
+        let mut result: MetricsQueryResponse = resp.json().await?;
+        result.trace_id = trace_id;
+        Ok(result)
+    }
+}
+
+/// Per-call options for [`Client::query`].
+#[derive(Debug, Clone, Default)]
+pub struct MplQueryOptions {
+    /// Override the edge deployment string sent as `queryEdgeDeployment`
+    /// (e.g. `"cloud.eu-central-1.aws"`). When `None` the server picks
+    /// a default for the configured edge URL.
+    pub edge_deployment: Option<String>,
+    /// User-supplied MPL `param` values; serialised as `queryParams`. Use
+    /// an empty map to omit the field entirely.
+    pub params: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MplQueryRequest {
+    apl: String,
+    start_time: DateTime<Utc>,
+    end_time: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    query_edge_deployment: Option<String>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    query_params: BTreeMap<String, String>,
+}
+
+/// Build an `Accept`-only header map.
+///
+/// Only ever called with our two static media-type literals, so the
+/// `HeaderValue` conversion can't fail.
+fn accept_header(value: &'static str) -> HeaderMap {
+    let mut headers = HeaderMap::with_capacity(1);
+    headers.insert(ACCEPT, HeaderValue::from_static(value));
+    headers
+}
+
+/// Format a timestamp the way the metrics-info endpoint requires:
+/// strict RFC3339, percent-encoded so `:` and `+` round-trip safely.
+fn encode_rfc3339(t: DateTime<Utc>) -> String {
+    url_segment(&t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+}
+
+/// Minimal percent-encoding for a URL path/query segment.
+fn url_segment(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char);
+            }
+            _ => {
+                // `write!` on a `String` is infallible.
+                let _ = write!(out, "%{b:02X}");
+            }
+        }
+    }
+    out
+}

--- a/src/metrics/model.rs
+++ b/src/metrics/model.rs
@@ -25,9 +25,9 @@ pub struct MetricInfo {
 
 /// Response body of `POST /v1/query/_mpl`.
 ///
-/// `trace_id` is populated from the response's `x-axiom-trace-id` (or
-/// `traceparent`) header — it is **not** part of the JSON body, so serde
-/// leaves it `None` on decode and the SDK fills it in.
+/// `trace_id` is populated from the response's `x-axiom-trace-id` header
+/// — it is **not** part of the JSON body, so serde leaves it `None` on
+/// decode and the SDK fills it in.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct MetricsQueryResponse {
     /// Per-series result. Empty when the query matched nothing.

--- a/src/metrics/model.rs
+++ b/src/metrics/model.rs
@@ -1,0 +1,58 @@
+//! Types describing the metrics-info and `_mpl` endpoints.
+//!
+//! The metrics API ships its own JSON encodings — different `Accept`
+//! headers select between a flat tag list and the richer `v2` info shape.
+//! The structs here cover both surfaces.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Metadata for a single metric, as returned by the metrics-info endpoint.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MetricInfo {
+    /// Metric type (e.g. `"counter"`, `"gauge"`, `"histogram"`). Renamed
+    /// from the wire `"type"` field to avoid the Rust keyword.
+    #[serde(rename = "type", default)]
+    pub kind: Option<String>,
+    /// Temporality reported by the producer (`"delta"`, `"cumulative"`, …).
+    #[serde(default)]
+    pub temporality: Option<String>,
+    /// Unit declared by the producer, if any.
+    #[serde(default)]
+    pub unit: Option<String>,
+}
+
+/// Response body of `POST /v1/query/_mpl`.
+///
+/// `trace_id` is populated from the response's `x-axiom-trace-id` (or
+/// `traceparent`) header — it is **not** part of the JSON body, so serde
+/// leaves it `None` on decode and the SDK fills it in.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct MetricsQueryResponse {
+    /// Per-series result. Empty when the query matched nothing.
+    #[serde(default)]
+    pub series: Vec<MetricsSeries>,
+    /// Trace identifier extracted from the response headers, when present.
+    #[serde(skip)]
+    pub trace_id: Option<String>,
+}
+
+/// One time-series in an MPL response.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MetricsSeries {
+    /// Source metric name.
+    pub metric: String,
+    /// Tag bindings that uniquely identify this series (e.g.
+    /// `{"service": "api", "code": "200"}`).
+    #[serde(default)]
+    pub tags: HashMap<String, String>,
+    /// First-sample timestamp in unix milliseconds.
+    pub start: i64,
+    /// Step size between samples in milliseconds.
+    pub resolution: u64,
+    /// Sample values; gaps are `None`. Indexed by
+    /// `start + i * resolution`.
+    #[serde(default)]
+    pub data: Vec<Option<f64>>,
+}

--- a/src/metrics/tests.rs
+++ b/src/metrics/tests.rs
@@ -1,0 +1,139 @@
+#![cfg(test)]
+
+use chrono::{TimeZone, Utc};
+use httpmock::prelude::*;
+use serde_json::json;
+
+use crate::{metrics::client::MplQueryOptions, Client};
+
+fn one_hour() -> (chrono::DateTime<chrono::Utc>, chrono::DateTime<chrono::Utc>) {
+    let end = Utc.with_ymd_and_hms(2026, 1, 1, 12, 0, 0).unwrap();
+    let start = end - chrono::Duration::hours(1);
+    (start, end)
+}
+
+#[tokio::test]
+async fn list_metrics() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start();
+    let (start, end) = one_hour();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/v1/query/metrics/info/datasets/ds/metrics")
+            .header("accept", "application/vnd.metrics-info.v2+json");
+        then.status(200).json_body(json!({
+            "http_requests_total": { "type": "counter", "temporality": "delta", "unit": null }
+        }));
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_edge_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    let info = client.metrics().list("ds", start, end).await?;
+    assert_eq!(info.len(), 1);
+    assert_eq!(
+        info.get("http_requests_total")
+            .and_then(|m| m.kind.as_deref()),
+        Some("counter")
+    );
+    mock.assert();
+    Ok(())
+}
+
+#[tokio::test]
+async fn list_tags() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start();
+    let (start, end) = one_hour();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/v1/query/metrics/info/datasets/ds/metrics/http_requests_total/tags");
+        then.status(200).json_body(json!(["code", "service"]));
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_edge_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    let tags = client
+        .metrics()
+        .tags("ds", "http_requests_total", start, end)
+        .await?;
+    assert_eq!(tags, vec!["code", "service"]);
+    mock.assert();
+    Ok(())
+}
+
+#[tokio::test]
+async fn tag_values() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start();
+    let (start, end) = one_hour();
+    let mock = server.mock(|when, then| {
+        when.method(GET).path(
+            "/v1/query/metrics/info/datasets/ds/metrics/http_requests_total/tags/code/values",
+        );
+        then.status(200).json_body(json!(["200", "404", "500"]));
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_edge_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    let values = client
+        .metrics()
+        .tag_values("ds", "http_requests_total", "code", start, end)
+        .await?;
+    assert_eq!(values, vec!["200", "404", "500"]);
+    mock.assert();
+    Ok(())
+}
+
+#[tokio::test]
+async fn query_mpl() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start();
+    let (start, end) = one_hour();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/v1/query/_mpl")
+            .header("accept", "application/json+metrics.v2");
+        then.status(200)
+            .header("x-axiom-trace-id", "trace-abc")
+            .json_body(json!({
+                "series": [
+                    {
+                        "metric": "http_requests_total",
+                        "tags": { "code": "200" },
+                        "start": 1_700_000_000_000_i64,
+                        "resolution": 60_000_u64,
+                        "data": [1.0, 2.0, null, 4.0]
+                    }
+                ]
+            }));
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_edge_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    let opts = MplQueryOptions {
+        edge_deployment: Some("cloud.eu-central-1.aws".into()),
+        ..Default::default()
+    };
+    let res = client
+        .metrics()
+        .query("metric('http_requests_total')", start, end, opts)
+        .await?;
+    assert_eq!(res.series.len(), 1);
+    assert_eq!(res.series[0].metric, "http_requests_total");
+    assert_eq!(res.series[0].data.len(), 4);
+    assert_eq!(res.trace_id.as_deref(), Some("trace-abc"));
+    mock.assert();
+    Ok(())
+}

--- a/src/metrics/tests.rs
+++ b/src/metrics/tests.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 use chrono::{TimeZone, Utc};
 use httpmock::prelude::*;
 use serde_json::json;
@@ -13,13 +11,41 @@ fn one_hour() -> (chrono::DateTime<chrono::Utc>, chrono::DateTime<chrono::Utc>) 
 }
 
 #[tokio::test]
+async fn spec() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(OPTIONS)
+            .path("/v1/query/_mpl")
+            .header("accept", "text/markdown");
+        then.status(200)
+            .header("content-type", "text/markdown")
+            .body("# MPL Spec\n\noperators: align, group by, where");
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_edge_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    let spec = client.metrics().spec().await?;
+    assert!(spec.starts_with("# MPL Spec"));
+    mock.assert_hits_async(1).await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn list_metrics() -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start();
     let (start, end) = one_hour();
+    // Lock down the wire shape: serde_qs renders timestamps via
+    // `DateTime<Utc>`'s default serializer, which uses RFC3339 with `Z`.
     let mock = server.mock(|when, then| {
         when.method(GET)
             .path("/v1/query/metrics/info/datasets/ds/metrics")
-            .header("accept", "application/vnd.metrics-info.v2+json");
+            .header("accept", "application/vnd.metrics-info.v2+json")
+            .query_param("start", "2026-01-01T11:00:00Z")
+            .query_param("end", "2026-01-01T12:00:00Z");
         then.status(200).json_body(json!({
             "http_requests_total": { "type": "counter", "temporality": "delta", "unit": null }
         }));
@@ -38,7 +64,7 @@ async fn list_metrics() -> Result<(), Box<dyn std::error::Error>> {
             .and_then(|m| m.kind.as_deref()),
         Some("counter")
     );
-    mock.assert();
+    mock.assert_hits_async(1).await;
     Ok(())
 }
 
@@ -63,7 +89,7 @@ async fn list_tags() -> Result<(), Box<dyn std::error::Error>> {
         .tags("ds", "http_requests_total", start, end)
         .await?;
     assert_eq!(tags, vec!["code", "service"]);
-    mock.assert();
+    mock.assert_hits_async(1).await;
     Ok(())
 }
 
@@ -89,7 +115,116 @@ async fn tag_values() -> Result<(), Box<dyn std::error::Error>> {
         .tag_values("ds", "http_requests_total", "code", start, end)
         .await?;
     assert_eq!(values, vec!["200", "404", "500"]);
-    mock.assert();
+    mock.assert_hits_async(1).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn tags_path_segment_is_percent_encoded() -> Result<(), Box<dyn std::error::Error>> {
+    // Metric / tag identifiers flow into URL path segments. Anything
+    // outside the RFC3986 unreserved set must be percent-encoded so the
+    // server sees the original name on the other side. Slash is the
+    // dangerous one: an unencoded `/` would split the path.
+    let server = MockServer::start();
+    let (start, end) = one_hour();
+    let mock = server.mock(|when, then| {
+        when.method(GET).path(
+            "/v1/query/metrics/info/datasets/ds/metrics/weird%2Fmetric%20name/tags",
+        );
+        then.status(200).json_body(json!(["k"]));
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_edge_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    let tags = client
+        .metrics()
+        .tags("ds", "weird/metric name", start, end)
+        .await?;
+    assert_eq!(tags, vec!["k"]);
+    mock.assert_hits_async(1).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn dataset_tags() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start();
+    let (start, end) = one_hour();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/v1/query/metrics/info/datasets/ds/tags");
+        then.status(200)
+            .json_body(json!(["env", "region", "service.name"]));
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_edge_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    let tags = client.metrics().dataset_tags("ds", start, end).await?;
+    assert_eq!(tags, vec!["env", "region", "service.name"]);
+    mock.assert_hits_async(1).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn dataset_tag_values() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start();
+    let (start, end) = one_hour();
+    let mock = server.mock(|when, then| {
+        when.method(GET)
+            .path("/v1/query/metrics/info/datasets/ds/tags/service.name/values");
+        then.status(200)
+            .json_body(json!(["frontend", "checkout", "payments"]));
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_edge_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    let values = client
+        .metrics()
+        .dataset_tag_values("ds", "service.name", start, end)
+        .await?;
+    assert_eq!(values, vec!["frontend", "checkout", "payments"]);
+    mock.assert_hits_async(1).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn find_metrics() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start();
+    let (start, end) = one_hour();
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/v1/query/metrics/info/datasets/ds/metrics")
+            .json_body(json!({ "value": "frontend" }));
+        then.status(200)
+            .json_body(json!(["http.server.duration", "http.server.requests"]));
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_edge_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    let metrics = client
+        .metrics()
+        .find_metrics("ds", "frontend", start, end)
+        .await?;
+    assert_eq!(
+        metrics,
+        vec!["http.server.duration", "http.server.requests"]
+    );
+    mock.assert_hits_async(1).await;
     Ok(())
 }
 
@@ -134,6 +269,76 @@ async fn query_mpl() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(res.series[0].metric, "http_requests_total");
     assert_eq!(res.series[0].data.len(), 4);
     assert_eq!(res.trace_id.as_deref(), Some("trace-abc"));
-    mock.assert();
+    mock.assert_hits_async(1).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn query_mpl_params_wire_shape() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start();
+    let (start, end) = one_hour();
+    // Assert the outgoing JSON body:
+    //   * uses `params` (not `queryParams`)
+    //   * prefixes every key with `param__` (no unprefixed keys leak
+    //     through)
+    //
+    // We parse the body in a matcher closure so we can assert
+    // *absence* of the wrong keys, not just presence of the right ones
+    // — `json_body_partial` alone would happily pass if both `params`
+    // and `queryParams` were sent.
+    let mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/v1/query/_mpl")
+            .matches(|req| {
+                let bytes = match req.body.as_deref() {
+                    Some(b) => b,
+                    None => return false,
+                };
+                let body: serde_json::Value = match serde_json::from_slice(bytes) {
+                    Ok(v) => v,
+                    Err(_) => return false,
+                };
+                let obj = match body.as_object() {
+                    Some(o) => o,
+                    None => return false,
+                };
+                // Wrong field name must not appear.
+                if obj.contains_key("queryParams") {
+                    return false;
+                }
+                let params = match obj.get("params").and_then(|v| v.as_object()) {
+                    Some(p) => p,
+                    None => return false,
+                };
+                // Prefixed keys present, raw keys absent.
+                params.contains_key("param__svc")
+                    && params.contains_key("param__window")
+                    && !params.contains_key("svc")
+                    && !params.contains_key("window")
+                    && params.get("param__svc").and_then(|v| v.as_str())
+                        == Some("\"frontend\"")
+                    && params.get("param__window").and_then(|v| v.as_str()) == Some("5m")
+            });
+        then.status(200).json_body(json!({ "series": [] }));
+    });
+    let client = Client::builder()
+        .no_env()
+        .with_url(server.base_url())
+        .with_edge_url(server.base_url())
+        .with_token("xaat-nope")
+        .build()?;
+
+    let mut params = std::collections::BTreeMap::new();
+    params.insert("svc".to_string(), "\"frontend\"".to_string());
+    params.insert("window".to_string(), "5m".to_string());
+    let opts = MplQueryOptions {
+        params,
+        ..Default::default()
+    };
+    let _ = client
+        .metrics()
+        .query("param $svc: string; param $window: Duration; _", start, end, opts)
+        .await?;
+    mock.assert_hits_async(1).await;
     Ok(())
 }

--- a/src/metrics/tests.rs
+++ b/src/metrics/tests.rs
@@ -128,9 +128,8 @@ async fn tags_path_segment_is_percent_encoded() -> Result<(), Box<dyn std::error
     let server = MockServer::start();
     let (start, end) = one_hour();
     let mock = server.mock(|when, then| {
-        when.method(GET).path(
-            "/v1/query/metrics/info/datasets/ds/metrics/weird%2Fmetric%20name/tags",
-        );
+        when.method(GET)
+            .path("/v1/query/metrics/info/datasets/ds/metrics/weird%2Fmetric%20name/tags");
         then.status(200).json_body(json!(["k"]));
     });
     let client = Client::builder()
@@ -287,38 +286,35 @@ async fn query_mpl_params_wire_shape() -> Result<(), Box<dyn std::error::Error>>
     // — `json_body_partial` alone would happily pass if both `params`
     // and `queryParams` were sent.
     let mock = server.mock(|when, then| {
-        when.method(POST)
-            .path("/v1/query/_mpl")
-            .matches(|req| {
-                let bytes = match req.body.as_deref() {
-                    Some(b) => b,
-                    None => return false,
-                };
-                let body: serde_json::Value = match serde_json::from_slice(bytes) {
-                    Ok(v) => v,
-                    Err(_) => return false,
-                };
-                let obj = match body.as_object() {
-                    Some(o) => o,
-                    None => return false,
-                };
-                // Wrong field name must not appear.
-                if obj.contains_key("queryParams") {
-                    return false;
-                }
-                let params = match obj.get("params").and_then(|v| v.as_object()) {
-                    Some(p) => p,
-                    None => return false,
-                };
-                // Prefixed keys present, raw keys absent.
-                params.contains_key("param__svc")
-                    && params.contains_key("param__window")
-                    && !params.contains_key("svc")
-                    && !params.contains_key("window")
-                    && params.get("param__svc").and_then(|v| v.as_str())
-                        == Some("\"frontend\"")
-                    && params.get("param__window").and_then(|v| v.as_str()) == Some("5m")
-            });
+        when.method(POST).path("/v1/query/_mpl").matches(|req| {
+            let bytes = match req.body.as_deref() {
+                Some(b) => b,
+                None => return false,
+            };
+            let body: serde_json::Value = match serde_json::from_slice(bytes) {
+                Ok(v) => v,
+                Err(_) => return false,
+            };
+            let obj = match body.as_object() {
+                Some(o) => o,
+                None => return false,
+            };
+            // Wrong field name must not appear.
+            if obj.contains_key("queryParams") {
+                return false;
+            }
+            let params = match obj.get("params").and_then(|v| v.as_object()) {
+                Some(p) => p,
+                None => return false,
+            };
+            // Prefixed keys present, raw keys absent.
+            params.contains_key("param__svc")
+                && params.contains_key("param__window")
+                && !params.contains_key("svc")
+                && !params.contains_key("window")
+                && params.get("param__svc").and_then(|v| v.as_str()) == Some("\"frontend\"")
+                && params.get("param__window").and_then(|v| v.as_str()) == Some("5m")
+        });
         then.status(200).json_body(json!({ "series": [] }));
     });
     let client = Client::builder()
@@ -337,7 +333,12 @@ async fn query_mpl_params_wire_shape() -> Result<(), Box<dyn std::error::Error>>
     };
     let _ = client
         .metrics()
-        .query("param $svc: string; param $window: Duration; _", start, end, opts)
+        .query(
+            "param $svc: string; param $window: Duration; _",
+            start,
+            end,
+            opts,
+        )
         .await?;
     mock.assert_hits_async(1).await;
     Ok(())


### PR DESCRIPTION
Adds two new modules — `dashboards` (v2 API) and `metrics` (info, tags, MPL queries) — and fills in the gaps the [axiomhq/skills `query-metrics`](https://github.com/axiomhq/skills/tree/main/skills/query-metrics) skill exposes but the SDK previously didn't.

## What's new

### Metrics (`client.metrics()`)

| Method | Endpoint |
|---|---|
| `list(ds, start, end)` | `GET …/datasets/{ds}/metrics` (v2 info) |
| `tags(ds, metric, start, end)` | `GET …/metrics/{m}/tags` |
| `tag_values(ds, metric, tag, start, end)` | `GET …/metrics/{m}/tags/{t}/values` |
| **`dataset_tags(ds, start, end)`** | `GET …/datasets/{ds}/tags` |
| **`dataset_tag_values(ds, tag, start, end)`** | `GET …/datasets/{ds}/tags/{t}/values` |
| **`find_metrics(ds, value, start, end)`** | `POST …/datasets/{ds}/metrics` `{value}` |
| **`spec()`** | `OPTIONS /v1/query/_mpl` (markdown spec) |
| `query(mpl, start, end, opts)` | `POST /v1/query/_mpl` |

### Dashboards (`client.dashboards()`)

`list` / `get` / `create` / `put` / `delete` against the `v2` API, with optimistic-version conflicts surfaced as a typed `Error::DashboardVersionConflict`.

### Datasets

`Dataset` now exposes `kind: Option<String>` (e.g. `"otel:metrics:v1"`) and `edge_deployment: Option<String>` so the metrics workflow ("find metrics datasets, route to the right regional edge") is reproducible from Rust.

## Wire-correctness fixes in this PR

- `metrics::query` previously sent parameters under `queryParams` with unprefixed keys; the server expects `params` with each key prefixed `param__`. Both fixed. Callers pass plain MPL variable names (`svc`, not `param__svc`); the SDK adds the prefix.
- `http::Client::delete` used to drop the response without calling `check_error`; any non-2xx from `DELETE` was silently treated as success. Now surfaces as `Error::Axiom`. Behavioural change for `annotations::delete` / `datasets::delete` / the new `dashboards::delete`.
- Dashboards write path no longer reaches into `reqwest::Response`; rate-limit / query-limit / ingest-limit mapping now applies to dashboard writes too.

## Style alignment

- Brand-new modules follow the existing `annotations` / `datasets` / `users` layout: `mod client; mod model; #[cfg(test)] mod tests;`, `Client<'client>` with `pub(crate) fn new`, `#[instrument(skip(self))]` on every method, doc-example in the module header, top-level accessor on `Client`.
- `dashboards::Client::put` takes an `UpsertOptions` struct rather than four trailing positional `Option`s — mirrors `MplQueryOptions` / `QueryOptions`.
- `Chart` is an open enum: `Known(KnownChart) | Unknown(Value)` (untagged), so server-side additions don't break `list`/`get` and round-trip byte-equivalent through `put`.
- `ChartBase::name` uses `skip_serializing_if = "Option::is_none"` so absent names don't round-trip as `"name": null` (would violate `additionalProperties: false`).
- Time-range query strings go through `serde_qs` rather than hand-built `start=...&end=...`.
- Generic bounds inlined as `impl Into<String> + FmtDebug` across the new modules.

## Commits

1. **refactor(http)** — `Response::status` / `method` / `path` / `text` / `body_text_unchecked`, `Client::options_with_headers`, `Client::delete` now checks status. Cleans up pre-existing `unwrap_used` lints in the http test builders so the whole crate is now clippy-clean.
2. **feat(metrics)** — wire-shape corrections + `spec` / `dataset_tags` / `dataset_tag_values` / `find_metrics`.
3. **feat(datasets)** — `kind` and `edge_deployment` on `Dataset`.
4. **refactor(dashboards)** — `CreateOptions` / `UpsertOptions`, open `Chart` enum, write path through the shared error path.

(Plus the original `feat: add dashboards (v2) and metrics (info, tags, MPL) modules` commit on the branch.)

## Validation

```
cargo build           — clean
cargo test --lib      — 48 passed (was 33 on the base commit, +15 new)
cargo clippy --all-targets — clean (0 errors, 0 warnings)
```

Tests cover every new endpoint, the `param__` prefix and `params` field name (with absence assertions for the wrong keys), the 412 conflict path *and* its `Error::Axiom` fallback when `currentVersion` is absent (asserting method/path/uid context is preserved), `Client::delete` propagating non-2xx, chart round-trip for both known and unknown variants, and path-segment percent-encoding for metric names containing `/` and spaces.
