### PR TITLE
fix(metrics): find_metrics returns metric→tags map, not Vec<String>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axiom-rs"
-version = "0.11.5"
+version = "0.11.6"
 authors = ["Arne Bahlo <arne@axiom.co>"]
 edition = "2018"
 rust-version = "1.60"

--- a/src/metrics/client.rs
+++ b/src/metrics/client.rs
@@ -171,6 +171,12 @@ impl<'client> Client<'client> {
     /// this when you know a specific entity (service, host, device) and
     /// want to find which metrics report it.
     ///
+    /// Returns a map of **metric name → the tag name(s) that carried the
+    /// searched value** on that metric, e.g. `{"http.server.duration":
+    /// ["service.name"]}`. The tags are useful for building a precise
+    /// follow-up filter (`where <tag> == <value>`) rather than guessing
+    /// which spelling holds the value.
+    ///
     /// # Errors
     /// Returns an error if the HTTP request fails or the response cannot be
     /// deserialised.
@@ -181,7 +187,7 @@ impl<'client> Client<'client> {
         value: impl Into<String> + FmtDebug,
         start: DateTime<Utc>,
         end: DateTime<Utc>,
-    ) -> Result<Vec<String>> {
+    ) -> Result<BTreeMap<String, Vec<String>>> {
         let dataset = dataset.into();
         let qs = TimeRange::new(start, end).to_query()?;
         let path = format!("/v1/query/metrics/info/datasets/{dataset}/metrics?{qs}");

--- a/src/metrics/tests.rs
+++ b/src/metrics/tests.rs
@@ -205,8 +205,12 @@ async fn find_metrics() -> Result<(), Box<dyn std::error::Error>> {
         when.method(POST)
             .path("/v1/query/metrics/info/datasets/ds/metrics")
             .json_body(json!({ "value": "frontend" }));
-        then.status(200)
-            .json_body(json!(["http.server.duration", "http.server.requests"]));
+        // The endpoint returns a map of metric -> the tag name(s) that
+        // carried the searched value, not a bare list of metric names.
+        then.status(200).json_body(json!({
+            "http.server.duration": ["service.name"],
+            "http.server.requests": ["service.name", "peer.service"],
+        }));
     });
     let client = Client::builder()
         .no_env()
@@ -219,9 +223,17 @@ async fn find_metrics() -> Result<(), Box<dyn std::error::Error>> {
         .metrics()
         .find_metrics("ds", "frontend", start, end)
         .await?;
+    assert_eq!(metrics.len(), 2);
     assert_eq!(
-        metrics,
-        vec!["http.server.duration", "http.server.requests"]
+        metrics.get("http.server.duration"),
+        Some(&vec!["service.name".to_string()])
+    );
+    assert_eq!(
+        metrics.get("http.server.requests"),
+        Some(&vec![
+            "service.name".to_string(),
+            "peer.service".to_string()
+        ])
     );
     mock.assert_hits_async(1).await;
     Ok(())


### PR DESCRIPTION
Provided by sand

## Problem

`Client::find_metrics` (the reverse lookup: *which metrics carry this tag value?*) hits `POST /v1/query/metrics/info/datasets/{ds}/metrics` with `{value}`. The server returns a JSON **object** mapping each metric name to the tag name(s) that carried the searched value:

```json
{
  "ha.sensor.battery":  ["host.name"],
  "ha.sensor.power":    ["host.name"]
}
```

(verified live against an `otel:metrics:v1` dataset).

The method deserialised this into `Result<Vec<String>>`, which can't decode an object — every real call would fail with a deserialization error (*expected a sequence, got a map*). The unit test mocked a bare array `["http.server.duration", ...]`, so it passed while disagreeing with the actual API.

## Fix

- Return `Result<BTreeMap<String, Vec<String>>>` — the real `metric → tags` shape, consistent with `list`'s `BTreeMap` return.
- Update the test to mock and assert the object payload.
- Expand the doc comment: the tag names let a caller build a precise `where <tag> == <value>` follow-up instead of guessing which tag spelling holds the value.

This is a breaking change to the `find_metrics` signature, but the prior signature never worked against the live endpoint.

## Verification

- `cargo fmt`
- `cargo clippy --no-default-features --features tokio,rustls-tls --all-targets` — clean
- `cargo test --lib --no-default-features --features tokio,rustls-tls` — 48 passed

(`--all-features` is not buildable: the `tokio` and `async-std` runtime features are mutually exclusive — pre-existing, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)